### PR TITLE
fix(api): correct return type for getmany function from single entity…

### DIFF
--- a/src/decorator/api/service.decorator.ts
+++ b/src/decorator/api/service.decorator.ts
@@ -105,7 +105,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						configurable: true,
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						enumerable: true,
-						value: async function (properties: TApiFunctionGetManyProperties<E>, eventManager?: EntityManager): Promise<E> {
+						value: async function (properties: TApiFunctionGetManyProperties<E>, eventManager?: EntityManager): Promise<Array<E>> {
 							const apiFunctionDecorator: (_target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
 								type: EApiFunctionType.GET_MANY,
@@ -132,7 +132,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 
 							const decoratedDescriptor: PropertyDescriptor = apiFunctionDecorator(this, EApiFunctionType.GET_MANY, descriptor);
 
-							return (decoratedDescriptor.value as (this: any, properties: TApiFunctionGetManyProperties<E>, eventManager?: EntityManager) => Promise<E>).call(this, properties, eventManager);
+							return (decoratedDescriptor.value as (this: any, properties: TApiFunctionGetManyProperties<E>, eventManager?: EntityManager) => Promise<Array<E>>).call(this, properties, eventManager);
 						},
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						writable: true,


### PR DESCRIPTION
### **User description**
… to array

The getMany function in ApiService decorator was incorrectly typed to return a single entity instead of an array of entities. Updated the return type annotation in both the function signature and the call to the decorated descriptor from Promise<E> to Promise<Array<E>>.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected the return type of `getMany` function to `Promise<Array<E>>`.

- Updated function signature and decorated descriptor call for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.decorator.ts</strong><dd><code>Corrected `getMany` function return type in ApiService</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/decorator/api/service.decorator.ts

<li>Changed the return type of <code>getMany</code> function from <code>Promise<E></code> to <code>Promise<Array<E>></code>.<br> <li> Updated both the function signature and the decorated descriptor call.


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/NestJS-Crud-Automator/pull/38/files#diff-4f2850e9b9dde190ff588a29b741642ba15e7205e86d30c895940e7404d2fc8f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>