### PR TITLE
refactor(api-controller): restructure controller decorator and add dt…

### DIFF
--- a/src/decorator/api/controller/decorator.ts
+++ b/src/decorator/api/controller/decorator.ts
@@ -1,7 +1,8 @@
-import type { IApiBaseEntity, IApiControllerProperties } from "../../interface";
-import type { TApiControllerConstructor } from "../../type";
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { IApiControllerProperties } from "@interface/decorator/api";
+import type { TApiControllerConstructor } from "@type/decorator/api/controller";
 
-import { ApiControllerFactory } from "../../factory/api/controller.factory";
+import { ApiControllerFactory } from "@factory/api";
 
 export const ApiController =
 	<E extends IApiBaseEntity>(options: IApiControllerProperties<E>) =>

--- a/src/decorator/api/controller/index.ts
+++ b/src/decorator/api/controller/index.ts
@@ -1,1 +1,2 @@
-export * from "./observable.decorator";
+export { ApiController } from "./decorator";
+export { ApiControllerObservable } from "./observable.decorator";

--- a/src/decorator/api/index.ts
+++ b/src/decorator/api/index.ts
@@ -1,5 +1,4 @@
 export * from "./controller";
-export * from "./controller.decorator";
 export * from "./function";
 export * from "./method.decorator";
 export * from "./property";

--- a/src/interface/utility/dto/generate-cache-key.interface.ts
+++ b/src/interface/utility/dto/generate-cache-key.interface.ts
@@ -1,0 +1,10 @@
+import type { EApiDtoType, EApiRouteType } from "@enum/decorator/api";
+import type { IApiControllerPropertiesRouteAutoDtoConfig } from "@interface/decorator/api";
+
+export interface IDtoGenerateCacheKey {
+	dtoConfig?: IApiControllerPropertiesRouteAutoDtoConfig;
+	dtoType: EApiDtoType;
+	entityName: string;
+	guardName?: string;
+	method: EApiRouteType;
+}

--- a/src/interface/utility/dto/index.ts
+++ b/src/interface/utility/dto/index.ts
@@ -1,0 +1,1 @@
+export type { IDtoGenerateCacheKey } from "./generate-cache-key.interface";

--- a/src/interface/utility/index.ts
+++ b/src/interface/utility/index.ts
@@ -1,2 +1,3 @@
 export type * from "./api/controller";
+export type * from "./dto";
 export { type IGetEntityColumnsProperties } from "./get-entity-columns-properties.interface";

--- a/src/utility/dto/generate-cache-key.utility.ts
+++ b/src/utility/dto/generate-cache-key.utility.ts
@@ -1,0 +1,10 @@
+import type { IDtoGenerateCacheKey } from "@interface/utility";
+
+/**
+ * Generates a unique cache key for DTO instances based on entity name, route method, DTO type, guard, and config.
+ * @param {IDtoGenerateCacheKey} key - The key object containing entity name, method, DTO type, guard name, and DTO config
+ * @returns {string} A unique string key for caching DTO instances
+ */
+export function DtoGenerateCacheKey(key: IDtoGenerateCacheKey): string {
+	return `${key.entityName}_${key.method}_${key.dtoType}_${key.guardName ?? "no-guard"}_${JSON.stringify(key.dtoConfig ?? {})}`;
+}

--- a/src/utility/dto/generate-exception.utility.ts
+++ b/src/utility/dto/generate-exception.utility.ts
@@ -9,6 +9,8 @@ import { EApiPropertyNumberType, EApiPropertyStringType } from "@enum/decorator/
 import { HttpStatus, type Type } from "@nestjs/common";
 import { CamelCaseString } from "@utility/camel-case-string.utility";
 
+const exceptionDtoCache: Map<HttpStatus, Type<unknown>> = new Map<HttpStatus, Type<unknown>>();
+
 /**
  * Creates exception DTOs with standardized properties based on HTTP status codes.
  * Generates a class with properties like correlationID, error name, message, status code, and timestamp,
@@ -17,6 +19,12 @@ import { CamelCaseString } from "@utility/camel-case-string.utility";
  * @returns {Type<unknown>} A generated DTO class for the exception
  */
 export function DtoGenerateException(httpStatus: HttpStatus): Type<unknown> {
+	const cached: Type<unknown> | undefined = exceptionDtoCache.get(httpStatus);
+
+	if (cached) {
+		return cached;
+	}
+
 	const errorName: string = HttpStatus[httpStatus];
 
 	class GeneratedErrorDTO {
@@ -71,6 +79,8 @@ export function DtoGenerateException(httpStatus: HttpStatus): Type<unknown> {
 	}
 
 	Object.defineProperty(GeneratedErrorDTO, "name", { value: `Exception${CamelCaseString(errorName)}DTO` });
+
+	exceptionDtoCache.set(httpStatus, GeneratedErrorDTO);
 
 	return GeneratedErrorDTO;
 }

--- a/src/utility/dto/index.ts
+++ b/src/utility/dto/index.ts
@@ -1,5 +1,6 @@
 export { analyzeEntityMetadata } from "./analize.utility";
 export { DtoBuildDecorator } from "./build-decorator.utility";
+export { DtoGenerateCacheKey } from "./generate-cache-key.utility";
 export { DtoGenerateDecorator } from "./generate-decorator.utility";
 export { DtoGenerateDynamic } from "./generate-dynamic.utility";
 export { DtoGenerateException } from "./generate-exception.utility";


### PR DESCRIPTION
…o cache utilities

Moved ApiController decorator from controller.decorator.ts to controller/decorator.ts for better organization. Updated import paths to use absolute imports with @ aliases. Added new utilities for DTO generation including cache key generation and exception handling. Created corresponding interfaces to support the new functionality. Updated index files to properly export the reorganized components.