### PR TITLE
feat(api): add inheritance support for entity metadata and swagger ge…

### DIFF
--- a/src/utility/api/controller/write/dto-swagger.utility.ts
+++ b/src/utility/api/controller/write/dto-swagger.utility.ts
@@ -28,6 +28,27 @@ import { CamelCaseString } from "@utility/camel-case-string.utility";
  */
 export function ApiControllerWriteDtoSwagger<E extends IApiBaseEntity>(target: object, entity: IApiEntity<E>, properties: IApiControllerProperties<E>, method: EApiRouteType, routeConfig: TApiControllerPropertiesRoute<E, typeof method>, entityMetadata: IApiEntity<E>): void {
 	const swaggerModels: Array<unknown> = (Reflect.getMetadata(DECORATORS.API_EXTRA_MODELS, target) ?? []) as Array<unknown>;
+	const entityNames: Array<string> = [];
+
+	if (typeof properties.entity === "function") {
+		let current: (new (...arguments_: Array<unknown>) => unknown) | undefined = properties.entity as unknown as new (...arguments_: Array<unknown>) => unknown;
+
+		while (current) {
+			entityNames.push(current.name);
+
+			const parentPrototype: null | object = Object.getPrototypeOf(current.prototype) as null | object;
+			const parentConstructor: unknown = parentPrototype ? Reflect.get(parentPrototype, "constructor") : undefined;
+			const parent: (new (...arguments_: Array<unknown>) => unknown) | undefined = typeof parentConstructor === "function" ? (parentConstructor as new (...arguments_: Array<unknown>) => unknown) : undefined;
+
+			if (!parent || parent === Object) {
+				break;
+			}
+
+			current = parent;
+		}
+	} else if (properties.entity.name) {
+		entityNames.push(properties.entity.name);
+	}
 
 	const requestDto: Type<unknown> | undefined = ApiControllerGetDto(properties, entity, method, EApiDtoType.REQUEST, routeConfig);
 	const queryDto: Type<unknown> | undefined = ApiControllerGetDto(properties, entity, method, EApiDtoType.QUERY, routeConfig);
@@ -41,8 +62,19 @@ export function ApiControllerWriteDtoSwagger<E extends IApiBaseEntity>(target: o
 			swaggerModels.push(dto);
 
 			const storage: MetadataStorage = MetadataStorage.getInstance();
+			const mergedMetadata: TMetadata = {};
+			let hasMetadata: boolean = false;
 
-			const metadata: TMetadata | undefined = storage.getMetadata(entityMetadata.name ?? "UnknownResource");
+			for (const entityName of [...entityNames].reverse()) {
+				const currentMetadata: TMetadata | undefined = storage.getMetadata(entityName);
+
+				if (currentMetadata) {
+					hasMetadata = true;
+					Object.assign(mergedMetadata, currentMetadata);
+				}
+			}
+
+			const metadata: TMetadata | undefined = hasMetadata ? mergedMetadata : undefined;
 
 			if (metadata)
 				for (const key of Object.keys(metadata)) {

--- a/src/utility/generate-entity-information.utility.ts
+++ b/src/utility/generate-entity-information.utility.ts
@@ -53,27 +53,96 @@ export function GenerateEntityInformation<E>(entity: IApiBaseEntity): IApiEntity
 	generatedEntity.name = entity.name;
 
 	const storage: MetadataStorage = MetadataStorage.getInstance();
+	const entityHierarchy: Array<new (...arguments_: Array<unknown>) => unknown> = [];
+	const entityNames: Array<string> = [];
 
-	// eslint-disable-next-line @elsikora/typescript/no-unsafe-function-type
-	const columnList: Array<ColumnMetadataArgs> = getMetadataArgsStorage().columns.filter(({ target }: ColumnMetadataArgs): boolean => (target as Function).name === entity.name);
+	if (typeof entity === "function") {
+		let current: (new (...arguments_: Array<unknown>) => unknown) | undefined = entity as unknown as new (...arguments_: Array<unknown>) => unknown;
 
-	// eslint-disable-next-line @elsikora/typescript/no-unsafe-function-type
-	const relationList: Array<RelationMetadataArgs> = getMetadataArgsStorage().relations.filter(({ target }: RelationMetadataArgs): boolean => (target as Function).name === entity.name);
+		while (current) {
+			entityHierarchy.push(current);
+			entityNames.push(current.name);
+
+			const parentPrototype: null | object = Object.getPrototypeOf(current.prototype) as null | object;
+			const parentConstructor: unknown = parentPrototype ? Reflect.get(parentPrototype, "constructor") : undefined;
+			const parent: (new (...arguments_: Array<unknown>) => unknown) | undefined = typeof parentConstructor === "function" ? (parentConstructor as new (...arguments_: Array<unknown>) => unknown) : undefined;
+
+			if (!parent || parent === Object) {
+				break;
+			}
+
+			current = parent;
+		}
+	} else if (entity.name) {
+		entityNames.push(entity.name);
+	}
+
+	const columnList: Array<ColumnMetadataArgs> = getMetadataArgsStorage().columns.filter(({ target }: ColumnMetadataArgs): boolean => {
+		if (typeof target === "string") {
+			return entityNames.includes(target);
+		}
+
+		if (typeof target !== "function") {
+			return false;
+		}
+
+		const targetEntity: new (...arguments_: Array<unknown>) => unknown = target as unknown as new (...arguments_: Array<unknown>) => unknown;
+
+		return entityHierarchy.some((currentEntity: new (...arguments_: Array<unknown>) => unknown): boolean => currentEntity === targetEntity || currentEntity.name === targetEntity.name) || entityNames.includes(targetEntity.name);
+	});
+
+	const relationList: Array<RelationMetadataArgs> = getMetadataArgsStorage().relations.filter(({ target }: RelationMetadataArgs): boolean => {
+		if (typeof target === "string") {
+			return entityNames.includes(target);
+		}
+
+		if (typeof target !== "function") {
+			return false;
+		}
+
+		const targetEntity: new (...arguments_: Array<unknown>) => unknown = target as unknown as new (...arguments_: Array<unknown>) => unknown;
+
+		return entityHierarchy.some((currentEntity: new (...arguments_: Array<unknown>) => unknown): boolean => currentEntity === targetEntity || currentEntity.name === targetEntity.name) || entityNames.includes(targetEntity.name);
+	});
 
 	const entityColumns: Array<IApiEntityColumn<E>> = [
-		...columnList.map(({ options, propertyName }: ColumnMetadataArgs) => ({
-			isPrimary: Boolean(options.primary),
-			metadata: (storage.getMetadata(entity.name ?? "UnknownResource", propertyName) as Record<string, unknown>) || undefined,
-			name: propertyName as keyof E,
-			// eslint-disable-next-line @elsikora/typescript/no-non-null-assertion
-			type: options.type!,
-		})),
-		...relationList.map(({ propertyName, relationType }: RelationMetadataArgs) => ({
-			isPrimary: false,
-			metadata: (storage.getMetadata(entity.name ?? "UnknownResource", propertyName) as Record<string, unknown>) || undefined,
-			name: propertyName as keyof E,
-			type: relationType as ColumnType,
-		})),
+		...columnList.map(({ options, propertyName }: ColumnMetadataArgs) => {
+			let metadata: Record<string, unknown> | undefined;
+
+			for (const entityName of entityNames) {
+				metadata = storage.getMetadata(entityName, propertyName) as Record<string, unknown> | undefined;
+
+				if (metadata) {
+					break;
+				}
+			}
+
+			return {
+				isPrimary: Boolean(options.primary),
+				metadata,
+				name: propertyName as keyof E,
+				// eslint-disable-next-line @elsikora/typescript/no-non-null-assertion
+				type: options.type!,
+			};
+		}),
+		...relationList.map(({ propertyName, relationType }: RelationMetadataArgs) => {
+			let metadata: Record<string, unknown> | undefined;
+
+			for (const entityName of entityNames) {
+				metadata = storage.getMetadata(entityName, propertyName) as Record<string, unknown> | undefined;
+
+				if (metadata) {
+					break;
+				}
+			}
+
+			return {
+				isPrimary: false,
+				metadata,
+				name: propertyName as keyof E,
+				type: relationType as ColumnType,
+			};
+		}),
 	];
 
 	for (const column of entityColumns) {

--- a/test/e2e/app/entity.ts
+++ b/test/e2e/app/entity.ts
@@ -226,7 +226,7 @@ export class E2eEntity {
 		isNullable: true,
 		shouldValidateNested: true,
 		type: EApiPropertyDescribeType.OBJECT,
-	} as unknown as { description: string; type: EApiPropertyDescribeType.OBJECT })
+	})
 	public document?: E2ePolicyDocumentDto;
 
 	@Column({ type: "varchar", nullable: true })

--- a/test/unit/utility/api/controller/write/dto-swagger.utility.test.ts
+++ b/test/unit/utility/api/controller/write/dto-swagger.utility.test.ts
@@ -1,14 +1,26 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { IApiControllerProperties } from "@interface/decorator/api";
 import type { IApiEntity } from "@interface/entity";
 
 import { MetadataStorage } from "@class/metadata-storage.class";
 import { PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT } from "@constant/decorator/api";
+import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
 import { EApiPropertyDescribeType, EApiRouteType } from "@enum/decorator/api";
 import { DECORATORS } from "@nestjs/swagger/dist/constants";
 import { ApiControllerWriteDtoSwagger } from "@utility/api/controller/write/dto-swagger.utility";
 import { describe, expect, it } from "vitest";
 
 class SwaggerDto {}
+
+abstract class InheritedSwaggerBaseEntity {
+	@ApiPropertyDescribe({
+		description: "owner",
+		type: EApiPropertyDescribeType.RELATION,
+	})
+	public owner!: { id: string };
+}
+
+class InheritedSwaggerEntity extends InheritedSwaggerBaseEntity {}
 
 describe("ApiControllerWriteDtoSwagger", () => {
 	it("registers relation DTOs in swagger extra models", () => {
@@ -43,7 +55,32 @@ describe("ApiControllerWriteDtoSwagger", () => {
 		const models = Reflect.getMetadata(DECORATORS.API_EXTRA_MODELS, target) as Array<{ name?: string }>;
 		const modelNames = models.map((model) => model?.name);
 
-		expect(modelNames).toContain(SwaggerDto.name);
-		expect(modelNames).toContain("SwaggerEntityGetBodyownerDTO");
+		expect(modelNames).toEqual(expect.arrayContaining([SwaggerDto.name, "SwaggerEntityGetBodyownerDTO"]));
+	});
+
+	it("registers inherited relation DTOs in swagger extra models", () => {
+		const entityMetadata: IApiEntity<{ owner?: { id: string } }> = {
+			columns: [],
+			name: InheritedSwaggerEntity.name,
+			primaryKey: undefined,
+			tableName: "inherited_swagger_entities",
+		};
+		const properties: IApiControllerProperties<{ owner?: { id: string } }> = {
+			entity: InheritedSwaggerEntity as unknown as IApiBaseEntity,
+			routes: {},
+		};
+		const routeConfig = {
+			dto: {
+				body: SwaggerDto,
+				query: SwaggerDto,
+				request: SwaggerDto,
+				response: SwaggerDto,
+			},
+		};
+		const target = {};
+
+		ApiControllerWriteDtoSwagger(target, entityMetadata, properties, EApiRouteType.GET, routeConfig as never, entityMetadata);
+
+		expect((Reflect.getMetadata(DECORATORS.API_EXTRA_MODELS, target) as Array<{ name?: string }>).map((model) => model?.name)).toContain("InheritedSwaggerEntityGetBodyownerDTO");
 	});
 });

--- a/test/unit/utility/generate-entity-information.utility.test.ts
+++ b/test/unit/utility/generate-entity-information.utility.test.ts
@@ -2,6 +2,9 @@ import "reflect-metadata";
 
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 
+import { PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT } from "@constant/decorator/api";
+import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
+import { EApiPropertyDescribeType, EApiPropertyStringType } from "@enum/decorator/api";
 import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 import { describe, expect, it } from "vitest";
@@ -19,16 +22,55 @@ class PlainEntity {
 	public id?: string;
 }
 
+abstract class InheritedInfoBaseEntity {
+	@PrimaryGeneratedColumn("uuid")
+	@ApiPropertyDescribe({
+		description: "id",
+		type: EApiPropertyDescribeType.UUID,
+	})
+	public id!: string;
+
+	@Column({ type: "varchar" })
+	@ApiPropertyDescribe({
+		description: "slug",
+		exampleValue: "shared-slug",
+		format: EApiPropertyStringType.STRING,
+		maxLength: 64,
+		minLength: 1,
+		pattern: "/^.+$/",
+		type: EApiPropertyDescribeType.STRING,
+	})
+	public slug!: string;
+}
+
+@Entity("extended_info_entities")
+class ExtendedInfoEntity extends InheritedInfoBaseEntity {
+	@Column({ type: "varchar" })
+	public name!: string;
+}
+
 describe("GenerateEntityInformation", () => {
 	it("builds entity metadata with table name and primary key", () => {
 		const metadata = GenerateEntityInformation<InfoEntity>(InfoEntity as unknown as IApiBaseEntity);
 
 		expect(metadata.tableName).toBe("info_entities");
 		expect(metadata.primaryKey?.name).toBe("id");
-		expect(metadata.columns.some((column) => column.name === "name")).toBe(true);
+		expect(metadata.columns.map(({ name }) => name)).toContain("name");
 	});
 
 	it("throws when entity metadata is missing", () => {
 		expect(() => GenerateEntityInformation<PlainEntity>(PlainEntity as unknown as IApiBaseEntity)).toThrowError("[NestJS-Crud-Automator] Table for entity PlainEntity not found in metadata storage");
+	});
+
+	it("includes inherited columns and property metadata from ancestor entities", () => {
+		const metadata = GenerateEntityInformation<ExtendedInfoEntity>(ExtendedInfoEntity as unknown as IApiBaseEntity);
+
+		expect(metadata.primaryKey?.name).toBe("id");
+		expect(metadata.columns.find((column) => column.name === "id")?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY]).toMatchObject({
+			type: EApiPropertyDescribeType.UUID,
+		});
+		expect(metadata.columns.find((column) => column.name === "slug")?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY]).toMatchObject({
+			type: EApiPropertyDescribeType.STRING,
+		});
 	});
 });


### PR DESCRIPTION
…neration

Enhanced dto-swagger utility to traverse entity inheritance chain and merge metadata from parent classes. Updated generate-entity-information utility to properly handle inherited properties and metadata. Added comprehensive test coverage for inheritance scenarios.