### PR TITLE
Support nested relation GET_LIST filters

### DIFF
--- a/ai/crud-automator/SKILL.md
+++ b/ai/crud-automator/SKILL.md
@@ -63,7 +63,8 @@ Use local source as the contract:
 - Request load config uses `shouldLoad`, `relationStrategy`, `serviceStrategy`, `relations`, `services`, and `shouldForceAllServicesToBeSpecified`.
 - `relations.request.load.relations` only filters loaded relations when `relationStrategy` is `MANUAL`; `services` is only required when `serviceStrategy` is `MANUAL`.
 - Response relation config: `relations.response.reference` and `relations.response.load.include`.
-- HTTP generated relation filters work on relation IDs, not nested query paths such as `author.username`.
+- HTTP generated relation filters use explicit one-level paths such as `author.id[...]` and `author.username[...]`; top-level `author[...]` is not generated or transformed.
+- Generated relation filters skip relation fields and object fields on the related entity.
 - For nested response relations, use TypeORM relation object maps in `response.load.include`.
 
 ## Subscriber Model

--- a/ai/crud-automator/pitfalls.md
+++ b/ai/crud-automator/pitfalls.md
@@ -73,7 +73,7 @@ DTO guard visibility is based on the route's configured guard class during DTO g
 
 ## Unsupported Generated GET_LIST Features
 
-Generated GET_LIST supports one `orderBy`, one `orderDirection`, `limit`, `page`, and bracketed filters. Use a custom method for multi-sort or relation-property filters like `author.username`.
+Generated GET_LIST supports one `orderBy`, one `orderDirection`, `limit`, `page`, and bracketed filters. Relation filters use one-level explicit paths such as `author.id[...]` and `author.username[...]`; use a custom method for multi-sort or deeper relation/object filters.
 
 ## Docs Drift
 

--- a/docs/guides/filtering-and-sorting/page.mdx
+++ b/docs/guides/filtering-and-sorting/page.mdx
@@ -206,6 +206,22 @@ GET /users?id[operator]=isnull
 GET /users?id[operator]=notnull
 ```
 
+## Relation Filters
+
+Generated GET_LIST routes filter relations through explicit one-level relation property paths:
+
+```typescript
+// Filter by related entity id
+GET /posts?author.id[operator]=eq&author.id[value]=550e8400-e29b-41d4-a716-446655440000
+
+// Filter by a scalar field on the related entity
+GET /posts?author.username[operator]=eq&author.username[value]=john_doe
+```
+
+Top-level relation filters such as `author[operator]=eq&author[value]=...` are not generated or transformed. Use `author.id[...]` for relation id filters.
+
+Only one relation level is generated. Relation fields and object fields on the related entity are skipped.
+
 ## Multiple Filters
 
 Combine multiple filters to narrow results:

--- a/docs/guides/relations/page.mdx
+++ b/docs/guides/relations/page.mdx
@@ -210,13 +210,21 @@ author: UserEntity;
 
 ## Filtering by Relations
 
-Generated GET_LIST relation filters work on the relation property itself. For relation metadata, the runtime maps the filter value to the related entity `id`.
+Generated GET_LIST relation filters use explicit one-level relation property paths. To filter by a related entity id, include the `id` field in the query path.
 
 ```
-GET /posts?author[operator]=eq&author[value]=550e8400-e29b-41d4-a716-446655440000
+GET /posts?author.id[operator]=eq&author.id[value]=550e8400-e29b-41d4-a716-446655440000
 ```
 
-Nested HTTP relation filters such as `author.username[operator]=eq` are not part of the generated query contract. Use a custom service/controller method when an endpoint needs relation-property filtering by fields other than the related `id`.
+The same syntax works for scalar fields on the related entity:
+
+```
+GET /posts?author.username[operator]=eq&author.username[value]=john_doe
+```
+
+Generated relation filters support one relation level. Relation fields and object fields on the related entity are not generated as nested query filters.
+
+Top-level relation filters such as `author[operator]=eq&author[value]=...` are not part of the generated query contract. Use `author.id[...]` instead.
 
 ```typescript
 // Programmatic filtering by relation

--- a/src/utility/api/controller/get-list/transform/filter.utility.ts
+++ b/src/utility/api/controller/get-list/transform/filter.utility.ts
@@ -1,9 +1,11 @@
 import type { EFilterOperation } from "@enum/filter";
 import type { IApiEntity, IApiEntityColumn } from "@interface/entity";
+import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
 import type { FindOptionsWhere } from "typeorm/index";
 
 import { PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT } from "@constant/decorator/api";
 import { EApiPropertyDescribeType } from "@enum/decorator/api";
+import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
 
 import { ApiControllerGetListTransformOperation } from "./operation.utility";
 
@@ -18,6 +20,7 @@ import { ApiControllerGetListTransformOperation } from "./operation.utility";
  */
 export function ApiControllerGetListTransformFilter<E>(query: Record<string, unknown>, entityMetadata: IApiEntity<E>): FindOptionsWhere<E> {
 	const filter: FindOptionsWhere<E> = {};
+	const filterRecord: Record<string, unknown> = filter;
 
 	for (const fullKey of Object.keys(query)) {
 		if (!fullKey.includes("[")) continue;
@@ -35,15 +38,46 @@ export function ApiControllerGetListTransformFilter<E>(query: Record<string, unk
 
 			if (!operation || !key || value === undefined || value === null) continue;
 
-			const column: IApiEntityColumn<E> | undefined = entityMetadata.columns.find((column: IApiEntityColumn<E>) => column.name == key);
+			const path: Array<string> = key.split(".");
 
-			// @ts-ignore
-			if (column?.metadata[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY].type === EApiPropertyDescribeType.RELATION) {
-				// @ts-ignore
-				filter[key as keyof E] = { id: ApiControllerGetListTransformOperation(operation, value) };
+			if (path.length === 1) {
+				const column: IApiEntityColumn<E> | undefined = entityMetadata.columns.find((column: IApiEntityColumn<E>) => column.name == key);
+				const columnMetadata: TApiPropertyDescribeProperties | undefined = column?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
+
+				if (!columnMetadata || columnMetadata.type === EApiPropertyDescribeType.RELATION) continue;
+
+				filterRecord[key] = ApiControllerGetListTransformOperation(operation, value);
 			} else {
-				// @ts-ignore
-				filter[key as keyof E] = ApiControllerGetListTransformOperation(operation, value);
+				// eslint-disable-next-line @elsikora/typescript/no-magic-numbers
+				if (path.length !== 2) continue;
+
+				const [relationName, nestedPropertyName]: Array<string | undefined> = path;
+
+				if (!relationName || !nestedPropertyName) continue;
+
+				const relationColumn: IApiEntityColumn<E> | undefined = entityMetadata.columns.find((column: IApiEntityColumn<E>) => column.name == relationName);
+				const relationMetadata: TApiPropertyDescribeProperties | undefined = relationColumn?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
+
+				if (relationMetadata?.type !== EApiPropertyDescribeType.RELATION || !relationColumn?.relation?.target) continue;
+
+				let relationEntityMetadata: IApiEntity<unknown>;
+
+				try {
+					relationEntityMetadata = GenerateEntityInformation(relationColumn.relation.target);
+				} catch {
+					continue;
+				}
+
+				const nestedColumn: IApiEntityColumn<unknown> | undefined = relationEntityMetadata.columns.find((column: IApiEntityColumn<unknown>) => column.name == nestedPropertyName);
+				const nestedColumnMetadata: TApiPropertyDescribeProperties | undefined = nestedColumn?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
+
+				if (!nestedColumnMetadata || nestedColumnMetadata.type === EApiPropertyDescribeType.RELATION || nestedColumnMetadata.type === EApiPropertyDescribeType.OBJECT) continue;
+
+				const relationFilter: Record<string, unknown> = (filterRecord[relationName] ?? {}) as Record<string, unknown>;
+
+				relationFilter[nestedPropertyName] = ApiControllerGetListTransformOperation(operation, value);
+
+				filterRecord[relationName] = relationFilter;
 			}
 		}
 	}

--- a/src/utility/dto/generate/core.utility.ts
+++ b/src/utility/dto/generate/core.utility.ts
@@ -1,5 +1,5 @@
 import type { IApiControllerPropertiesRouteAutoDtoConfig } from "@interface/decorator/api";
-import type { IApiEntity } from "@interface/entity";
+import type { IApiEntity, IApiEntityColumn } from "@interface/entity";
 import type { Type } from "@nestjs/common";
 import type { IAuthGuard } from "@nestjs/passport";
 import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
@@ -19,6 +19,7 @@ import { DtoGetGetListQueryBaseClass } from "@utility/dto/get/get-list-query-bas
 import { DtoIsPropertyShouldBeMarked } from "@utility/dto/is/property/should-be-marked.utility";
 import { DtoIsShouldBeGenerated } from "@utility/dto/is/should-be-generated.utility";
 import { ErrorException } from "@utility/error/exception.utility";
+import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
 import { HasPairedCustomSuffixesFieldsValidator } from "@validator/has/paired-custom-suffixes-fields.validator";
 import { Validate } from "class-validator";
 
@@ -82,15 +83,61 @@ export function DtoGenerate<E>(entity: ObjectLiteral, entityMetadata: IApiEntity
 			});
 		}
 	}
+
+	const queryFilterProperties: Array<{
+		entityMetadata: IApiEntity<unknown>;
+		metadata: TApiPropertyDescribeProperties;
+		name: string;
+	}> = [];
+
+	if (method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY) {
+		for (const property of markedProperties) {
+			if (property.metadata.type !== EApiPropertyDescribeType.RELATION) {
+				queryFilterProperties.push({
+					entityMetadata: entityMetadata as IApiEntity<unknown>,
+					metadata: property.metadata,
+					name: property.name as string,
+				});
+
+				continue;
+			}
+
+			const relationColumn: IApiEntityColumn<E> | undefined = entityMetadata.columns.find((column: IApiEntityColumn<E>): boolean => column.name == property.name);
+
+			if (!relationColumn?.relation?.target) continue;
+
+			let relationEntityMetadata: IApiEntity<unknown>;
+
+			try {
+				relationEntityMetadata = GenerateEntityInformation(relationColumn.relation.target);
+			} catch {
+				continue;
+			}
+
+			for (const relationProperty of relationEntityMetadata.columns) {
+				const relationPropertyMetadata: TApiPropertyDescribeProperties | undefined = relationProperty.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
+
+				if (!relationPropertyMetadata || relationPropertyMetadata.type === EApiPropertyDescribeType.RELATION || relationPropertyMetadata.type === EApiPropertyDescribeType.OBJECT) continue;
+
+				if (!relationProperty.isPrimary && !DtoIsPropertyShouldBeMarked(method, dtoType, relationProperty.name, relationPropertyMetadata, relationProperty.isPrimary, currentGuard)) continue;
+
+				queryFilterProperties.push({
+					entityMetadata: relationEntityMetadata,
+					metadata: relationPropertyMetadata,
+					name: `${property.name as string}.${relationProperty.name as string}`,
+				});
+			}
+		}
+	}
 	const BaseClass: Type = method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY ? DtoGetGetListQueryBaseClass<E>(entity, entityMetadata, method, dtoType) : class {};
 
 	class GeneratedDTO extends BaseClass {
 		constructor() {
 			super();
 
-			for (const property of markedProperties) {
-				if (method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY) {
-					Object.defineProperty(this, `${property.name as string}[value]`, {
+			if (method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY) {
+				for (const property of queryFilterProperties) {
+					Object.defineProperty(this, `${property.name}[value]`, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
@@ -100,7 +147,7 @@ export function DtoGenerate<E>(entity: ObjectLiteral, entityMetadata: IApiEntity
 						writable: true,
 					});
 
-					Object.defineProperty(this, `${property.name as string}[values]`, {
+					Object.defineProperty(this, `${property.name}[values]`, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
@@ -110,7 +157,7 @@ export function DtoGenerate<E>(entity: ObjectLiteral, entityMetadata: IApiEntity
 						writable: true,
 					});
 
-					Object.defineProperty(this, `${property.name as string}[operator]`, {
+					Object.defineProperty(this, `${property.name}[operator]`, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
@@ -119,7 +166,9 @@ export function DtoGenerate<E>(entity: ObjectLiteral, entityMetadata: IApiEntity
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						writable: true,
 					});
-				} else {
+				}
+			} else {
+				for (const property of markedProperties) {
 					Object.defineProperty(this, property.name, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -141,44 +190,49 @@ export function DtoGenerate<E>(entity: ObjectLiteral, entityMetadata: IApiEntity
 	DtoAutoContextPush(GeneratedDTO.prototype, method, dtoType);
 
 	try {
-		for (const property of markedProperties) {
-			const generatedDTOs: Record<string, Type<unknown>> | undefined = DtoGenerateDynamic(method, property.metadata, entityMetadata, dtoType, property.name as string, currentGuard);
+		if (method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY) {
+			for (const property of queryFilterProperties) {
+				const decorators: Array<PropertyDecorator> | undefined = DtoBuildDecorator(method, property.metadata, property.entityMetadata, dtoType, property.name, currentGuard);
 
-			const decorators: Array<PropertyDecorator> | undefined = DtoBuildDecorator(method, property.metadata, entityMetadata, dtoType, property.name as string, currentGuard, generatedDTOs);
+				if (decorators) {
+					for (const [, decorator] of decorators.entries()) {
+						decorator(GeneratedDTO.prototype, `${property.name}[value]`);
 
-			if (decorators) {
-				for (const [, decorator] of decorators.entries()) {
-					if (method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY) {
-						decorator(GeneratedDTO.prototype, `${property.name as string}[value]`);
-
-						DtoGenerateFilterDecorator(property.metadata, entityMetadata)(GeneratedDTO.prototype, `${property.name as string}[operator]`);
-					} else {
-						decorator(GeneratedDTO.prototype, property.name as string);
+						DtoGenerateFilterDecorator(property.metadata, property.entityMetadata)(GeneratedDTO.prototype, `${property.name}[operator]`);
 					}
 				}
-			}
 
-			if (method === EApiRouteType.GET_LIST && dtoType === EApiDtoType.QUERY) {
-				// @ts-ignore
-				const metadataArray: TApiPropertyDescribeProperties = { ...property.metadata, isArray: true, isUniqueItems: false, maxItems: DTO_GENERATE_CONSTANT.MAXIMUM_FILTER_PROPERTIES, minItems: DTO_GENERATE_CONSTANT.MINIMUM_FILTER_PROPERTIES };
+				const metadataArray: TApiPropertyDescribeProperties = { ...property.metadata, isArray: true, isUniqueItems: false, maxItems: DTO_GENERATE_CONSTANT.MAXIMUM_FILTER_PROPERTIES, minItems: DTO_GENERATE_CONSTANT.MINIMUM_FILTER_PROPERTIES } as TApiPropertyDescribeProperties;
 
-				const decoratorsArray: Array<PropertyDecorator> | undefined = DtoBuildDecorator(method, metadataArray, entityMetadata, dtoType, property.name as string, currentGuard);
+				const decoratorsArray: Array<PropertyDecorator> | undefined = DtoBuildDecorator(method, metadataArray, property.entityMetadata, dtoType, property.name, currentGuard);
 
 				if (decoratorsArray) {
 					for (const [, decorator] of decoratorsArray.entries()) {
-						decorator(GeneratedDTO.prototype, `${property.name as string}[values]`);
+						decorator(GeneratedDTO.prototype, `${property.name}[values]`);
 					}
 				}
 			}
+		} else {
+			for (const property of markedProperties) {
+				const generatedDTOs: Record<string, Type<unknown>> | undefined = DtoGenerateDynamic(method, property.metadata, entityMetadata, dtoType, property.name as string, currentGuard);
 
-			if (property.metadata.type === EApiPropertyDescribeType.OBJECT && Array.isArray(property.metadata.dataType)) {
-				// @ts-ignore
-				extraModels.push(...property.metadata.dataType);
-			}
+				const decorators: Array<PropertyDecorator> | undefined = DtoBuildDecorator(method, property.metadata, entityMetadata, dtoType, property.name as string, currentGuard, generatedDTOs);
 
-			if (generatedDTOs) {
-				for (const [, value] of Object.entries(generatedDTOs)) {
-					extraModels.push(value);
+				if (decorators) {
+					for (const [, decorator] of decorators.entries()) {
+						decorator(GeneratedDTO.prototype, property.name as string);
+					}
+				}
+
+				if (property.metadata.type === EApiPropertyDescribeType.OBJECT && Array.isArray(property.metadata.dataType)) {
+					// @ts-ignore
+					extraModels.push(...property.metadata.dataType);
+				}
+
+				if (generatedDTOs) {
+					for (const [, value] of Object.entries(generatedDTOs)) {
+						extraModels.push(value);
+					}
 				}
 			}
 		}

--- a/test/e2e/app/policy.ts
+++ b/test/e2e/app/policy.ts
@@ -66,6 +66,12 @@ export class E2ePolicySubscriber extends ApiAuthorizationPolicyBase<E2eEntity> {
 	}
 
 	private readonly ownerScope = (context: IApiAuthorizationRuleContext<E2eEntity>) => {
+		const permissions: unknown = context.principal.claims?.permissions;
+
+		if (Array.isArray(permissions) && permissions.some((permission: unknown): boolean => permission === "admin.item.unscoped")) {
+			return {};
+		}
+
 		return {
 			where: {
 				ownerId: this.resolveScopedOwnerId(context.principal),

--- a/test/e2e/http/crud.e2e.test.ts
+++ b/test/e2e/http/crud.e2e.test.ts
@@ -833,17 +833,107 @@ describe("CRUD routes (E2E)", () => {
 		expect(listResponse.json().count).toBe("999");
 	});
 
-	it("filters by relation property", async () => {
+	it("filters by explicit relation properties", async () => {
 		await seedFilterItems();
-
-		const listResponse = await fastify.inject({
-			headers: adminHeaders,
-			method: "GET",
-			url: `/items?limit=10&page=1&owner[operator]=eq&owner[value]=${E2E_OWNER_ID}`,
+		await ownerService.repository.save({ id: E2E_OWNER_ID_OTHER, name: "Other Owner" });
+		await service.repository.save({
+			count: 7,
+			id: "filter-other-owner",
+			name: "OtherOwner",
+			ownerId: E2E_OWNER_ID_OTHER,
 		});
 
-		expect(listResponse.statusCode).toBe(200);
-		expect(listResponse.json().items).not.toHaveLength(0);
+		const unscopedAdminHeaders = {
+			...adminHeaders,
+			"x-user-permissions": "admin.item.unscoped",
+		};
+
+		const idMatchResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: `/items?limit=1&page=1&owner.id[operator]=eq&owner.id[value]=${E2E_OWNER_ID}`,
+		});
+
+		expect(idMatchResponse.statusCode).toBe(200);
+		expect(idMatchResponse.json().items).toHaveLength(1);
+		expect(idMatchResponse.json().totalCount).toBe(3);
+
+		const idMissResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: `/items?limit=1&page=1&owner.id[operator]=eq&owner.id[value]=${E2E_OWNER_ID_OTHER}`,
+		});
+
+		expect(idMissResponse.statusCode).toBe(200);
+		expect(idMissResponse.json().items).toHaveLength(1);
+		expect(idMissResponse.json().items[0]?.id).toBe("filter-other-owner");
+		expect(idMissResponse.json().totalCount).toBe(1);
+
+		const nameMatchResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: "/items?limit=1&page=1&owner.name[operator]=eq&owner.name[value]=Owner",
+		});
+
+		expect(nameMatchResponse.statusCode).toBe(200);
+		expect(nameMatchResponse.json().items).toHaveLength(1);
+		expect(nameMatchResponse.json().totalCount).toBe(3);
+
+		const nameMissResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: "/items?limit=1&page=1&owner.name[operator]=eq&owner.name[value]=Other%20Owner",
+		});
+
+		expect(nameMissResponse.statusCode).toBe(200);
+		expect(nameMissResponse.json().items).toHaveLength(1);
+		expect(nameMissResponse.json().items[0]?.id).toBe("filter-other-owner");
+		expect(nameMissResponse.json().totalCount).toBe(1);
+
+		const legacyRelationResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: `/items?limit=10&page=1&owner[operator]=eq&owner[value]=${E2E_OWNER_ID_OTHER}`,
+		});
+
+		expect(legacyRelationResponse.statusCode).toBe(200);
+		expect(
+			legacyRelationResponse
+				.json()
+				.items.map((item: { id: string }) => item.id)
+				.sort(),
+		).toEqual(["filter-1", "filter-2", "filter-3", "filter-other-owner"]);
+		expect(legacyRelationResponse.json().totalCount).toBe(4);
+
+		const invalidRelationResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: "/items?limit=10&page=1&owner.missing[operator]=eq&owner.missing[value]=Owner",
+		});
+
+		expect(invalidRelationResponse.statusCode).toBe(200);
+		expect(
+			invalidRelationResponse
+				.json()
+				.items.map((item: { id: string }) => item.id)
+				.sort(),
+		).toEqual(["filter-1", "filter-2", "filter-3", "filter-other-owner"]);
+		expect(invalidRelationResponse.json().totalCount).toBe(4);
+
+		const deeperRelationResponse = await fastify.inject({
+			headers: unscopedAdminHeaders,
+			method: "GET",
+			url: "/items?limit=10&page=1&owner.name..deep[operator]=eq&owner.name..deep[value]=Owner",
+		});
+
+		expect(deeperRelationResponse.statusCode).toBe(200);
+		expect(
+			deeperRelationResponse
+				.json()
+				.items.map((item: { id: string }) => item.id)
+				.sort(),
+		).toEqual(["filter-1", "filter-2", "filter-3", "filter-other-owner"]);
+		expect(deeperRelationResponse.json().totalCount).toBe(4);
 	});
 
 	it("returns conflict for duplicate unique fields", async () => {

--- a/test/unit/utility/api/controller/get-list/transform/filter.utility.test.ts
+++ b/test/unit/utility/api/controller/get-list/transform/filter.utility.test.ts
@@ -3,9 +3,7 @@ import "reflect-metadata";
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
 
-import { MetadataStorage } from "@class/metadata-storage.class";
 import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
-import { PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT } from "@constant/decorator/api";
 import { EApiPropertyDescribeType } from "@enum/decorator/api";
 import { EFilterOperation } from "@enum/filter";
 import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
@@ -16,6 +14,10 @@ import { describe, expect, it } from "vitest";
 @Entity("owners")
 class OwnerEntity {
 	@PrimaryGeneratedColumn("uuid")
+	@ApiPropertyDescribe({
+		type: EApiPropertyDescribeType.UUID,
+		description: "owner id",
+	} as TApiPropertyDescribeProperties)
 	public id!: string;
 
 	@ApiPropertyDescribe({
@@ -31,6 +33,10 @@ class ItemEntity {
 	@PrimaryGeneratedColumn("uuid")
 	public id!: string;
 
+	@ApiPropertyDescribe({
+		type: EApiPropertyDescribeType.STRING,
+		description: "item name",
+	} as TApiPropertyDescribeProperties)
 	@Column({ type: "varchar" })
 	public name!: string;
 
@@ -43,29 +49,72 @@ class ItemEntity {
 }
 
 describe("ApiControllerGetListTransformFilter", () => {
-	it("transforms relation filters to use nested id", () => {
-		const storage = MetadataStorage.getInstance();
-		storage.setMetadata(ItemEntity.name, "name", PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY, {
-			type: EApiPropertyDescribeType.STRING,
-			description: "item name",
-		} as TApiPropertyDescribeProperties);
-		storage.setMetadata(ItemEntity.name, "owner", PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY, {
-			type: EApiPropertyDescribeType.RELATION,
-			description: "owner",
-		} as TApiPropertyDescribeProperties);
-
+	it("transforms scalar filters", () => {
 		const metadata = GenerateEntityInformation<ItemEntity>(ItemEntity as unknown as IApiBaseEntity);
 		const query = {
 			"name[operator]": EFilterOperation.EQ,
 			"name[value]": "Sample",
+		};
+
+		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);
+
+		expect(filter).toHaveProperty("name");
+		expect((filter.name as { value?: unknown }).value).toBe("Sample");
+	});
+
+	it("transforms explicit relation id filters", () => {
+		const metadata = GenerateEntityInformation<ItemEntity>(ItemEntity as unknown as IApiBaseEntity);
+		const query = {
+			"owner.id[operator]": EFilterOperation.EQ,
+			"owner.id[value]": "owner-1",
+		};
+
+		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);
+
+		expect(filter).toHaveProperty("owner");
+		expect(filter.owner).toHaveProperty("id");
+		expect(((filter.owner as { id?: { value?: unknown } }).id as { value?: unknown }).value).toBe("owner-1");
+	});
+
+	it("transforms nested relation scalar filters", () => {
+		const metadata = GenerateEntityInformation<ItemEntity>(ItemEntity as unknown as IApiBaseEntity);
+		const query = {
+			"owner.name[operator]": EFilterOperation.EQ,
+			"owner.name[value]": "Owner",
+		};
+
+		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);
+
+		expect(filter).toHaveProperty("owner");
+		expect(filter.owner).toHaveProperty("name");
+		expect(((filter.owner as { name?: { value?: unknown } }).name as { value?: unknown }).value).toBe("Owner");
+	});
+
+	it("ignores legacy top-level relation filters", () => {
+		const metadata = GenerateEntityInformation<ItemEntity>(ItemEntity as unknown as IApiBaseEntity);
+		const query = {
 			"owner[operator]": EFilterOperation.EQ,
 			"owner[value]": "owner-1",
 		};
 
 		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);
 
-		expect(filter).toHaveProperty("name");
-		expect(filter).toHaveProperty("owner");
-		expect(filter.owner).toHaveProperty("id");
+		expect(filter).not.toHaveProperty("owner");
+	});
+
+	it("ignores invalid nested relation paths", () => {
+		const metadata = GenerateEntityInformation<ItemEntity>(ItemEntity as unknown as IApiBaseEntity);
+		const query = {
+			"owner.missing[operator]": EFilterOperation.EQ,
+			"owner.missing[value]": "Owner",
+			"owner.name..deep[operator]": EFilterOperation.EQ,
+			"owner.name..deep[value]": "Owner",
+			"owner.name.deep[operator]": EFilterOperation.EQ,
+			"owner.name.deep[value]": "Owner",
+		};
+
+		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);
+
+		expect(filter).not.toHaveProperty("owner");
 	});
 });

--- a/test/unit/utility/dto/generate/core.utility.test.ts
+++ b/test/unit/utility/dto/generate/core.utility.test.ts
@@ -8,6 +8,7 @@ import { ApiPropertyObject } from "@decorator/api/property/object.decorator";
 import { ApiPropertyString } from "@decorator/api/property/string.decorator";
 import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
 import { EApiDtoType, EApiPropertyDateIdentifier, EApiPropertyDateType, EApiPropertyDescribeType, EApiPropertyNumberType, EApiPropertyStringType, EApiRouteType } from "@enum/decorator/api";
+import { EFilterOperationString, EFilterOperationUuid } from "@enum/filter";
 import { DECORATORS } from "@nestjs/swagger/dist/constants";
 import { DtoGenerate } from "@utility/dto/generate/core.utility";
 import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
@@ -101,6 +102,18 @@ class DtoRelatedEntity {
 		type: EApiPropertyDescribeType.UUID,
 	})
 	public id!: string;
+
+	@Column({ type: "varchar" })
+	@ApiPropertyDescribe({
+		description: "owner name",
+		exampleValue: "Owner",
+		format: EApiPropertyStringType.STRING,
+		maxLength: 50,
+		minLength: 1,
+		pattern: "/^.+$/",
+		type: EApiPropertyDescribeType.STRING,
+	})
+	public name!: string;
 }
 
 class MetaInfo {
@@ -307,6 +320,20 @@ describe("DtoGenerate", () => {
 		expect(queryInstance).toBeDefined();
 		expect(queryInstance && "name[value]" in queryInstance).toBe(true);
 		expect(queryInstance && "name[operator]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner[value]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner[operator]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner.id[value]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner.id[values]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner.id[operator]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner.name[value]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner.name[values]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner.name[operator]" in queryInstance).toBe(true);
+
+		const ownerIdOperatorMetadata = queryDto ? Reflect.getMetadata(DECORATORS.API_MODEL_PROPERTIES, queryDto.prototype, "owner.id[operator]") : undefined;
+		const ownerNameOperatorMetadata = queryDto ? Reflect.getMetadata(DECORATORS.API_MODEL_PROPERTIES, queryDto.prototype, "owner.name[operator]") : undefined;
+
+		expect(ownerIdOperatorMetadata?.enum).toEqual(Object.values(EFilterOperationUuid));
+		expect(ownerNameOperatorMetadata?.enum).toEqual(Object.values(EFilterOperationString));
 	});
 
 	it("serializes nested manual DTOs in response mode without manual isResponse", () => {


### PR DESCRIPTION
## Summary
- Add strict one-level relation field filters for generated GET_LIST queries using `relation.field[...]` syntax.
- Stop generating or transforming top-level relation filters like `relation[...]` as id fallbacks.
- Update docs, internal guidance, and unit/e2e coverage for relation id, nested scalar, legacy, invalid, and pagination/count behavior.

## Test plan
- `npm run lint:types`
- `npm run test:unit -- test/unit/utility/api/controller/get-list/transform/filter.utility.test.ts test/unit/utility/dto/generate/core.utility.test.ts`
- `npm run test:e2e`