### PR TITLE
feat(api): configure generated crud transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,9 +521,27 @@ Declare the discriminator field, such as `channel` or `mode`, on every variant D
 
 Root-level discriminator selection runs before Nest can infer a concrete DTO class, so global `ValidationPipe` options are not applied automatically to the selected variant. Add `validatorOptions` or `transformOptions` to the discriminated body config when a route needs specific validation or transformation settings.
 
-Function decorators support explicit transaction modes without exposing `EntityManager` as a public method argument:
+Generated service functions and explicit function decorators support transaction modes without exposing `EntityManager` as a public method argument:
 
 ```typescript
+import { ApiService, ApiServiceBase, EApiFunctionTransactionMode, EApiFunctionType } from "@elsikora/nestjs-crud-automator";
+
+@ApiService<UserEntity>({
+	entity: UserEntity,
+	functions: {
+		[EApiFunctionType.CREATE]: {
+			transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+		},
+	},
+})
+export class UserService extends ApiServiceBase<UserEntity> {}
+```
+
+The `functions` map accepts generated function types (`CREATE`, `UPDATE`, `DELETE`, `GET`, `GET_LIST`, `GET_MANY`). Omitted entries keep the default `SUPPORTS` mode. `CUSTOM` is configured separately with `@ApiFunctionCustom`.
+
+```typescript
+import { ApiFunctionCustom, EApiFunctionTransactionMode } from "@elsikora/nestjs-crud-automator";
+
 @ApiFunctionCustom<UserEntity>({
 	action: "bulkPromote",
 	entity: UserEntity,
@@ -1141,7 +1159,7 @@ Yes, the GET_LIST operation automatically includes pagination with limit and pag
 
 ### How is filtering implemented?
 
-Filtering is implemented using a flexible operator-based approach that supports various operations like equals, contains, greater than, less than, between, etc. Filters can be applied to any property of your entity.
+Filtering is implemented using a flexible operator-based approach that supports operations like equals, contains, greater than, less than, and between. Filters apply to generated query fields: scalar entity fields and explicit one-level relation property paths such as `author.id[...]` or `author.username[...]`; hidden query fields, object fields, relation-valued fields, and top-level `author[...]` relation filters are skipped.
 
 ### Can I use this with NestJS microservices?
 

--- a/ai/crud-automator/SKILL.md
+++ b/ai/crud-automator/SKILL.md
@@ -43,6 +43,7 @@ Use local source as the contract:
 - Service/function `get`, `getList`, and `getMany` receive TypeORM options.
 - Generated service/context `delete` is `Promise<void>`; direct decorator internals have a known return-shape inconsistency, so document and test the intended surface before changing it.
 - `@ApiFunctionCustom({ action, entity, transaction })` is for custom service commands that need function lifecycle, subscribers, and transaction context.
+- `@ApiService({ entity, functions })` can configure transaction modes for generated CRUD functions keyed by `EApiFunctionType.CREATE`, `UPDATE`, `DELETE`, `GET`, `GET_LIST`, and `GET_MANY`; omitted entries default to `SUPPORTS`, and `CUSTOM` belongs to `@ApiFunctionCustom`.
 - Transaction modes are `SUPPORTS`, `REQUIRED`, `MANDATORY`, and `NONE`.
 - Inside decorated service execution, use `this.getApiFunctionContext()` for `operations`, `repository`, `eventManager`, and `getRepository`.
 - `ApiFunctionTransactionScope.runWithDataSource()` and `runWithEntityManager()` provide external transaction scope; CRUD `operations` reject without a decorated service context.

--- a/docs/api-reference/decorators/api-service/api-service/page.mdx
+++ b/docs/api-reference/decorators/api-service/api-service/page.mdx
@@ -5,8 +5,13 @@ Extends a provider with CRUD-ready methods (`create`, `update`, `delete`, `get`,
 ## Signature
 
 ```typescript
-@ApiService<E extends IApiBaseEntity>({ entity }: TApiServiceProperties<E>)
+@ApiService<E extends IApiBaseEntity>({ entity, functions }: TApiServiceProperties<E>)
 ```
+
+| Property                           | Type                          | Description                                                                 |
+| ---------------------------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| `entity`                           | `new () => E`                 | Entity constructor for generated CRUD functions.                            |
+| `functions[type].transaction.mode` | `EApiFunctionTransactionMode` | Optional transaction mode for a generated function. Defaults to `SUPPORTS`. |
 
 ## Requirements
 
@@ -28,8 +33,21 @@ Extends a provider with CRUD-ready methods (`create`, `update`, `delete`, `get`,
 ## Example
 
 ```typescript
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { ApiService, ApiServiceBase, EApiFunctionTransactionMode, EApiFunctionType } from "@elsikora/nestjs-crud-automator";
+import { UserEntity } from "./user.entity";
+
 @Injectable()
-@ApiService<UserEntity>({ entity: UserEntity })
+@ApiService<UserEntity>({
+	entity: UserEntity,
+	functions: {
+		[EApiFunctionType.CREATE]: {
+			transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+		},
+	},
+})
 export class UserService extends ApiServiceBase<UserEntity> {
 	constructor(
 		@InjectRepository(UserEntity)
@@ -39,6 +57,8 @@ export class UserService extends ApiServiceBase<UserEntity> {
 	}
 }
 ```
+
+The `functions` map accepts generated function types (`CREATE`, `UPDATE`, `DELETE`, `GET`, `GET_LIST`, `GET_MANY`). Omitted entries keep the default `SUPPORTS` transaction mode. It does not configure `CUSTOM`; use `@ApiFunctionCustom` for custom service commands.
 
 ## Related resources
 

--- a/docs/core-concepts/services/page.mdx
+++ b/docs/core-concepts/services/page.mdx
@@ -160,6 +160,34 @@ export class UserService extends ApiServiceBase<UserEntity> {
 
 Do not pass `EntityManager` as a public service method argument. Use function `transaction.mode` and nested decorated calls so the framework propagates the active transaction through `ApiFunctionContextStorage`.
 
+Generated CRUD functions can be configured directly on `@ApiService`:
+
+```typescript filename="post.service.ts" copy
+import { ApiService, ApiServiceBase, EApiFunctionTransactionMode, EApiFunctionType } from "@elsikora/nestjs-crud-automator";
+
+@Injectable()
+@ApiService<PostEntity>({
+	entity: PostEntity,
+	functions: {
+		[EApiFunctionType.CREATE]: {
+			transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+		},
+	},
+})
+export class PostService extends ApiServiceBase<PostEntity> {
+	constructor(
+		@InjectRepository(PostEntity)
+		public repository: Repository<PostEntity>,
+	) {
+		super();
+	}
+}
+```
+
+The `functions` map accepts generated function types (`CREATE`, `UPDATE`, `DELETE`, `GET`, `GET_LIST`, `GET_MANY`). Omitted entries keep the default `SUPPORTS` mode, and `CUSTOM` is configured with `@ApiFunctionCustom` instead.
+
+Custom commands can use `@ApiFunctionCustom` when the operation needs domain-specific method bodies:
+
 ```typescript filename="post.service.ts" copy
 import { ApiFunctionCustom, EApiFunctionTransactionMode } from "@elsikora/nestjs-crud-automator";
 

--- a/src/class/api/route-runtime.class.ts
+++ b/src/class/api/route-runtime.class.ts
@@ -318,7 +318,7 @@ export class ApiRouteRuntime {
 
 				const query: TApiControllerGetListQuery<E> = targets.query;
 				const { limit, orderBy, orderDirection, page, ...getListQuery }: TApiControllerGetListQuery<E> = query;
-				const filter: TApiFunctionGetListPropertiesWhere<E> = ApiControllerGetListTransformFilter<E>(getListQuery, options.entityMetadata);
+				const filter: TApiFunctionGetListPropertiesWhere<E> = ApiControllerGetListTransformFilter<E>(getListQuery, options.entityMetadata, routeConfig.security?.authentication?.guard);
 				const scopedFilter: Array<TApiFunctionGetListPropertiesWhere<E>> | TApiFunctionGetListPropertiesWhere<E> | undefined = AuthorizationScopeMergeWhere(filter, authorizationDecision?.scope?.where);
 
 				const requestProperties: TApiFunctionGetListProperties<E> = {

--- a/src/decorator/api/function/create.decorator.ts
+++ b/src/decorator/api/function/create.decorator.ts
@@ -73,6 +73,17 @@ export function ApiFunctionCreate<E extends IApiBaseEntity>(properties: IApiFunc
 				},
 				entity,
 				mode: transactionMode,
+				onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+					const entityInstance: E = new entity();
+
+					const errorExecutionContext: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>> = {
+						DATA: { eventManager, repository: this.repository },
+						ENTITY: entityInstance,
+						FUNCTION_TYPE: EApiFunctionType.CREATE,
+					};
+
+					await ApiSubscriberExecutor.executeFunctionErrorSubscribers(this.constructor as new (...arguments_: Array<unknown>) => unknown, entityInstance, EApiFunctionType.CREATE, EApiSubscriberOnType.BEFORE_ERROR, errorExecutionContext, error);
+				},
 				repository: this.repository,
 			});
 		};

--- a/src/decorator/api/function/delete.decorator.ts
+++ b/src/decorator/api/function/delete.decorator.ts
@@ -84,6 +84,17 @@ export function ApiFunctionDelete<E extends IApiBaseEntity>(properties: IApiFunc
 				},
 				entity,
 				mode: transactionMode,
+				onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+					const entityInstance: E = new entity();
+
+					const errorExecutionContext: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>> = {
+						DATA: { criteria, eventManager, repository: this.repository },
+						ENTITY: entityInstance,
+						FUNCTION_TYPE: EApiFunctionType.DELETE,
+					};
+
+					await ApiSubscriberExecutor.executeFunctionErrorSubscribers(this.constructor as new (...arguments_: Array<unknown>) => unknown, entityInstance, EApiFunctionType.DELETE, EApiSubscriberOnType.BEFORE_ERROR, errorExecutionContext, error);
+				},
 				repository: this.repository,
 			});
 		};

--- a/src/decorator/api/function/get/decorator.ts
+++ b/src/decorator/api/function/get/decorator.ts
@@ -71,6 +71,17 @@ export function ApiFunctionGet<E extends IApiBaseEntity>(properties: IApiFunctio
 				},
 				entity,
 				mode: transactionMode,
+				onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+					const entityInstance: E = new entity();
+
+					const errorExecutionContext: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>> = {
+						DATA: { eventManager, getProperties, repository: this.repository },
+						ENTITY: entityInstance,
+						FUNCTION_TYPE: EApiFunctionType.GET,
+					};
+
+					await ApiSubscriberExecutor.executeFunctionErrorSubscribers(this.constructor as new (...arguments_: Array<unknown>) => unknown, entityInstance, EApiFunctionType.GET, EApiSubscriberOnType.BEFORE_ERROR, errorExecutionContext, error);
+				},
 				repository: this.repository,
 			});
 		};

--- a/src/decorator/api/function/get/list.decorator.ts
+++ b/src/decorator/api/function/get/list.decorator.ts
@@ -67,6 +67,17 @@ export function ApiFunctionGetList<E extends IApiBaseEntity>(properties: IApiFun
 				},
 				entity,
 				mode: transactionMode,
+				onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+					const entityInstance: E = new entity();
+
+					const errorExecutionContext: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>> = {
+						DATA: { eventManager, getListProperties, repository: this.repository },
+						ENTITY: entityInstance,
+						FUNCTION_TYPE: EApiFunctionType.GET_LIST,
+					};
+
+					await ApiSubscriberExecutor.executeFunctionErrorSubscribers(this.constructor as new (...arguments_: Array<unknown>) => unknown, entityInstance, EApiFunctionType.GET_LIST, EApiSubscriberOnType.BEFORE_ERROR, errorExecutionContext, error);
+				},
 				repository: this.repository,
 			});
 		};

--- a/src/decorator/api/function/get/many.decorator.ts
+++ b/src/decorator/api/function/get/many.decorator.ts
@@ -72,6 +72,17 @@ export function ApiFunctionGetMany<E extends IApiBaseEntity>(properties: IApiFun
 				},
 				entity,
 				mode: transactionMode,
+				onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+					const entityInstance: E = new entity();
+
+					const errorExecutionContext: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>> = {
+						DATA: { eventManager, getManyProperties, repository: this.repository },
+						ENTITY: entityInstance,
+						FUNCTION_TYPE: EApiFunctionType.GET_MANY,
+					};
+
+					await ApiSubscriberExecutor.executeFunctionErrorSubscribers(this.constructor as new (...arguments_: Array<unknown>) => unknown, entityInstance, EApiFunctionType.GET_MANY, EApiSubscriberOnType.BEFORE_ERROR, errorExecutionContext, error);
+				},
 				repository: this.repository,
 			});
 		};

--- a/src/decorator/api/function/update.decorator.ts
+++ b/src/decorator/api/function/update.decorator.ts
@@ -86,6 +86,17 @@ export function ApiFunctionUpdate<E extends IApiBaseEntity>(properties: IApiFunc
 				},
 				entity,
 				mode: transactionMode,
+				onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+					const entityInstance: E = new entity();
+
+					const errorExecutionContext: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>> = {
+						DATA: { criteria, eventManager, repository: this.repository },
+						ENTITY: entityInstance,
+						FUNCTION_TYPE: EApiFunctionType.UPDATE,
+					};
+
+					await ApiSubscriberExecutor.executeFunctionErrorSubscribers(this.constructor as new (...arguments_: Array<unknown>) => unknown, entityInstance, EApiFunctionType.UPDATE, EApiSubscriberOnType.BEFORE_ERROR, errorExecutionContext, error);
+				},
 				repository: this.repository,
 			});
 		};

--- a/src/decorator/api/service/decorator.ts
+++ b/src/decorator/api/service/decorator.ts
@@ -3,6 +3,7 @@ import type { IApiGetListResponseResult } from "@interface/decorator/api";
 import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateCriteria, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
 import type { TApiServiceProperties } from "@type/decorator/api/service";
 
+import { ApiServiceBase } from "@class/api/service-base.class";
 import { ApiFunction } from "@decorator/api/function";
 import { EApiFunctionType } from "@enum/decorator/api";
 
@@ -15,7 +16,7 @@ import { EApiFunctionType } from "@enum/decorator/api";
  * @see {@link https://elsikora.com/docs/nestjs-crud-automator/core-concepts/services | Core Concepts - Services}
  */
 export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProperties<E>) {
-	const { entity }: TApiServiceProperties<E> = properties;
+	const { entity, functions }: TApiServiceProperties<E> = properties;
 
 	// eslint-disable-next-line @elsikora/typescript/no-explicit-any
 	return function <TFunction extends new (...arguments_: Array<any>) => object>(target: TFunction): TFunction {
@@ -28,7 +29,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 				// eslint-disable-next-line @elsikora/typescript/no-unsafe-argument
 				super(..._arguments);
 
-				if (!Object.prototype.hasOwnProperty.call(this, EApiFunctionType.GET_LIST)) {
+				if (ApiServiceShouldDefineFunction(this, originalConstructor.prototype, EApiFunctionType.GET_LIST)) {
 					Object.defineProperty(this, EApiFunctionType.GET_LIST, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -37,6 +38,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						value: async function (properties: TApiFunctionGetListProperties<E>): Promise<IApiGetListResponseResult<E>> {
 							const apiFunctionDecorator: (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
+								transaction: functions?.[EApiFunctionType.GET_LIST]?.transaction,
 								type: EApiFunctionType.GET_LIST,
 							});
 
@@ -68,7 +70,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 					});
 				}
 
-				if (!Object.prototype.hasOwnProperty.call(this, EApiFunctionType.GET)) {
+				if (ApiServiceShouldDefineFunction(this, originalConstructor.prototype, EApiFunctionType.GET)) {
 					Object.defineProperty(this, EApiFunctionType.GET, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -77,6 +79,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						value: async function (properties: TApiFunctionGetProperties<E>): Promise<E> {
 							const apiFunctionDecorator: (_target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
+								transaction: functions?.[EApiFunctionType.GET]?.transaction,
 								type: EApiFunctionType.GET,
 							});
 
@@ -108,7 +111,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 					});
 				}
 
-				if (!Object.prototype.hasOwnProperty.call(this, EApiFunctionType.GET_MANY)) {
+				if (ApiServiceShouldDefineFunction(this, originalConstructor.prototype, EApiFunctionType.GET_MANY)) {
 					Object.defineProperty(this, EApiFunctionType.GET_MANY, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -117,6 +120,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						value: async function (properties: TApiFunctionGetManyProperties<E>): Promise<Array<E>> {
 							const apiFunctionDecorator: (_target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
+								transaction: functions?.[EApiFunctionType.GET_MANY]?.transaction,
 								type: EApiFunctionType.GET_MANY,
 							});
 
@@ -148,7 +152,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 					});
 				}
 
-				if (!Object.prototype.hasOwnProperty.call(this, EApiFunctionType.CREATE)) {
+				if (ApiServiceShouldDefineFunction(this, originalConstructor.prototype, EApiFunctionType.CREATE)) {
 					Object.defineProperty(this, EApiFunctionType.CREATE, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -157,6 +161,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						value: async function (properties: TApiFunctionCreateProperties<E>): Promise<E> {
 							const apiFunctionDecorator: (_target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
+								transaction: functions?.[EApiFunctionType.CREATE]?.transaction,
 								type: EApiFunctionType.CREATE,
 							});
 
@@ -188,7 +193,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 					});
 				}
 
-				if (!Object.prototype.hasOwnProperty.call(this, EApiFunctionType.UPDATE)) {
+				if (ApiServiceShouldDefineFunction(this, originalConstructor.prototype, EApiFunctionType.UPDATE)) {
 					Object.defineProperty(this, EApiFunctionType.UPDATE, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -197,6 +202,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						value: async function (criteria: TApiFunctionUpdateCriteria<E>, properties: TApiFunctionUpdateProperties<E>): Promise<E> {
 							const apiFunctionDecorator: (_target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
+								transaction: functions?.[EApiFunctionType.UPDATE]?.transaction,
 								type: EApiFunctionType.UPDATE,
 							});
 
@@ -228,7 +234,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 					});
 				}
 
-				if (!Object.prototype.hasOwnProperty.call(this, EApiFunctionType.DELETE)) {
+				if (ApiServiceShouldDefineFunction(this, originalConstructor.prototype, EApiFunctionType.DELETE)) {
 					Object.defineProperty(this, EApiFunctionType.DELETE, {
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						configurable: true,
@@ -237,6 +243,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 						value: async function (criteria: TApiFunctionDeleteCriteria<E>): Promise<void> {
 							const apiFunctionDecorator: (_target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor = ApiFunction({
 								entity,
+								transaction: functions?.[EApiFunctionType.DELETE]?.transaction,
 								type: EApiFunctionType.DELETE,
 							});
 
@@ -261,7 +268,7 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 
 							const decoratedDescriptor: PropertyDescriptor = apiFunctionDecorator(this, EApiFunctionType.DELETE, descriptor);
 
-							return (decoratedDescriptor.value as (this: unknown, criteria: TApiFunctionDeleteCriteria<E>) => Promise<void>).call(this, criteria);
+							await (decoratedDescriptor.value as (this: unknown, criteria: TApiFunctionDeleteCriteria<E>) => Promise<unknown>).call(this, criteria);
 						},
 						// eslint-disable-next-line @elsikora/typescript/naming-convention
 						writable: true,
@@ -274,4 +281,29 @@ export function ApiService<E extends IApiBaseEntity>(properties: TApiServiceProp
 
 		return ExtendedClass as TFunction;
 	};
+}
+
+/**
+ * Checks whether ApiService should define a generated function on the instance.
+ * @param {unknown} instance - Service instance after constructor field initializers ran.
+ * @param {unknown} prototype - Original service prototype.
+ * @param {EApiFunctionType} functionName - Generated function name.
+ * @returns {boolean} True when no direct implementation exists.
+ */
+function ApiServiceShouldDefineFunction(instance: unknown, prototype: unknown, functionName: EApiFunctionType): boolean {
+	if (Object.prototype.hasOwnProperty.call(instance, functionName)) {
+		return false;
+	}
+
+	let currentPrototype: null | object = typeof prototype === "object" && prototype !== null ? prototype : null;
+
+	while (currentPrototype && currentPrototype !== Object.prototype) {
+		if (Object.prototype.hasOwnProperty.call(currentPrototype, functionName)) {
+			return currentPrototype === ApiServiceBase.prototype;
+		}
+
+		currentPrototype = Object.getPrototypeOf(currentPrototype) as null | object;
+	}
+
+	return true;
 }

--- a/src/type/decorator/api/service/function/index.ts
+++ b/src/type/decorator/api/service/function/index.ts
@@ -1,0 +1,2 @@
+export { type TApiServiceFunctionPropertiesMap } from "./map.type";
+export { type TApiServiceFunctionProperties } from "./properties.type";

--- a/src/type/decorator/api/service/function/map.type.ts
+++ b/src/type/decorator/api/service/function/map.type.ts
@@ -1,0 +1,6 @@
+import type { EApiFunctionType } from "@enum/decorator/api";
+import type { TApiServiceFunctionProperties } from "@type/decorator/api/service/function/properties.type";
+
+export type TApiServiceFunctionPropertiesMap = {
+	[EApiFunctionType.CUSTOM]?: never;
+} & Partial<Record<Exclude<EApiFunctionType, EApiFunctionType.CUSTOM>, TApiServiceFunctionProperties>>;

--- a/src/type/decorator/api/service/function/properties.type.ts
+++ b/src/type/decorator/api/service/function/properties.type.ts
@@ -1,0 +1,7 @@
+import type { EApiFunctionTransactionMode } from "@enum/decorator/api";
+
+export type TApiServiceFunctionProperties = {
+	transaction: {
+		mode: EApiFunctionTransactionMode;
+	};
+};

--- a/src/type/decorator/api/service/index.ts
+++ b/src/type/decorator/api/service/index.ts
@@ -1,2 +1,3 @@
+export type * from "./function";
 export { type TApiServiceKeys } from "./keys.type";
 export { type TApiServiceProperties } from "./properties.type";

--- a/src/type/decorator/api/service/properties.type.ts
+++ b/src/type/decorator/api/service/properties.type.ts
@@ -1,3 +1,6 @@
+import type { TApiServiceFunctionPropertiesMap } from "@type/decorator/api/service/function";
+
 export type TApiServiceProperties<E> = {
 	entity: new () => E;
+	functions?: TApiServiceFunctionPropertiesMap;
 };

--- a/src/utility/api/controller/get-list/transform/filter.utility.ts
+++ b/src/utility/api/controller/get-list/transform/filter.utility.ts
@@ -1,10 +1,13 @@
 import type { EFilterOperation } from "@enum/filter";
 import type { IApiEntity, IApiEntityColumn } from "@interface/entity";
+import type { Type } from "@nestjs/common";
+import type { IAuthGuard } from "@nestjs/passport";
 import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
 import type { FindOptionsWhere } from "typeorm/index";
 
 import { PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT } from "@constant/decorator/api";
-import { EApiPropertyDescribeType } from "@enum/decorator/api";
+import { EApiDtoType, EApiPropertyDescribeType, EApiRouteType } from "@enum/decorator/api";
+import { DtoIsPropertyShouldBeMarked } from "@utility/dto/is/property/should-be-marked.utility";
 import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
 
 import { ApiControllerGetListTransformOperation } from "./operation.utility";
@@ -15,10 +18,11 @@ import { ApiControllerGetListTransformOperation } from "./operation.utility";
  * Handles special cases for relation properties.
  * @param {Record<string, unknown>} query - The query parameters from the HTTP request
  * @param {IApiEntity<E>} entityMetadata - The entity metadata containing column information
+ * @param {Type<IAuthGuard>} currentGuard - Optional guard used to mirror generated query DTO visibility.
  * @returns {FindOptionsWhere<E>} The TypeORM filter object for the query
  * @template E - The entity type
  */
-export function ApiControllerGetListTransformFilter<E>(query: Record<string, unknown>, entityMetadata: IApiEntity<E>): FindOptionsWhere<E> {
+export function ApiControllerGetListTransformFilter<E>(query: Record<string, unknown>, entityMetadata: IApiEntity<E>, currentGuard?: Type<IAuthGuard>): FindOptionsWhere<E> {
 	const filter: FindOptionsWhere<E> = {};
 	const filterRecord: Record<string, unknown> = filter;
 
@@ -44,7 +48,7 @@ export function ApiControllerGetListTransformFilter<E>(query: Record<string, unk
 				const column: IApiEntityColumn<E> | undefined = entityMetadata.columns.find((column: IApiEntityColumn<E>) => column.name == key);
 				const columnMetadata: TApiPropertyDescribeProperties | undefined = column?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
 
-				if (!columnMetadata || columnMetadata.type === EApiPropertyDescribeType.RELATION) continue;
+				if (!column || !columnMetadata || !DtoIsPropertyShouldBeMarked(EApiRouteType.GET_LIST, EApiDtoType.QUERY, key, columnMetadata, column.isPrimary, currentGuard) || columnMetadata.type === EApiPropertyDescribeType.RELATION) continue;
 
 				filterRecord[key] = ApiControllerGetListTransformOperation(operation, value);
 			} else {
@@ -58,7 +62,7 @@ export function ApiControllerGetListTransformFilter<E>(query: Record<string, unk
 				const relationColumn: IApiEntityColumn<E> | undefined = entityMetadata.columns.find((column: IApiEntityColumn<E>) => column.name == relationName);
 				const relationMetadata: TApiPropertyDescribeProperties | undefined = relationColumn?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
 
-				if (relationMetadata?.type !== EApiPropertyDescribeType.RELATION || !relationColumn?.relation?.target) continue;
+				if (!relationColumn || relationMetadata?.type !== EApiPropertyDescribeType.RELATION || !relationColumn.relation?.target || !DtoIsPropertyShouldBeMarked(EApiRouteType.GET_LIST, EApiDtoType.QUERY, relationName, relationMetadata, relationColumn.isPrimary, currentGuard)) continue;
 
 				let relationEntityMetadata: IApiEntity<unknown>;
 
@@ -71,7 +75,9 @@ export function ApiControllerGetListTransformFilter<E>(query: Record<string, unk
 				const nestedColumn: IApiEntityColumn<unknown> | undefined = relationEntityMetadata.columns.find((column: IApiEntityColumn<unknown>) => column.name == nestedPropertyName);
 				const nestedColumnMetadata: TApiPropertyDescribeProperties | undefined = nestedColumn?.metadata?.[PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT.METADATA_KEY] as TApiPropertyDescribeProperties | undefined;
 
-				if (!nestedColumnMetadata || nestedColumnMetadata.type === EApiPropertyDescribeType.RELATION || nestedColumnMetadata.type === EApiPropertyDescribeType.OBJECT) continue;
+				if (!nestedColumn || !nestedColumnMetadata || nestedColumnMetadata.type === EApiPropertyDescribeType.RELATION || nestedColumnMetadata.type === EApiPropertyDescribeType.OBJECT) continue;
+
+				if (!nestedColumn.isPrimary && !DtoIsPropertyShouldBeMarked(EApiRouteType.GET_LIST, EApiDtoType.QUERY, nestedPropertyName, nestedColumnMetadata, nestedColumn.isPrimary, currentGuard)) continue;
 
 				const relationFilter: Record<string, unknown> = (filterRecord[relationName] ?? {}) as Record<string, unknown>;
 

--- a/src/utility/api/function-transaction.utility.ts
+++ b/src/utility/api/function-transaction.utility.ts
@@ -14,23 +14,40 @@ import { ErrorException } from "@utility/error/exception.utility";
  * @param {(eventManager: EntityManager | undefined) => Promise<R>} options.callback - Function body to run with the resolved transaction manager.
  * @param {new (...arguments_: Array<unknown>) => E} options.entity - Entity constructor associated with the function.
  * @param {EApiFunctionTransactionMode} options.mode - Transaction mode to enforce.
- * @param {Repository<E>} options.repository - Repository used to open new transactions when required.
+ * @param {(eventManager: EntityManager | undefined, error: Error) => Promise<void>} [options.onPreflightError] - Error hook for transaction mode conflicts before the function body starts.
+ * @param {Repository<E>} [options.repository] - Repository used to open new transactions when required.
  * @returns {Promise<R>} Callback result.
  */
-export async function ApiFunctionExecuteWithTransaction<E extends IApiBaseEntity, R>(options: { callback: (eventManager: EntityManager | undefined) => Promise<R>; entity: new (...arguments_: Array<unknown>) => E; mode: EApiFunctionTransactionMode; repository: Repository<E> }): Promise<R> {
+export async function ApiFunctionExecuteWithTransaction<E extends IApiBaseEntity, R>(options: { callback: (eventManager: EntityManager | undefined) => Promise<R>; entity: new (...arguments_: Array<unknown>) => E; mode: EApiFunctionTransactionMode; onPreflightError?: (eventManager: EntityManager | undefined, error: Error) => Promise<void>; repository?: Repository<E> }): Promise<R> {
 	const activeEventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
 
 	if (options.mode === EApiFunctionTransactionMode.NONE && activeEventManager) {
-		throw ErrorException("ApiFunction transaction mode NONE cannot run inside an active transaction");
+		const error: Error = ErrorException("ApiFunction transaction mode NONE cannot run inside an active transaction");
+
+		await options.onPreflightError?.(activeEventManager, error);
+
+		throw error;
 	}
 
 	if (options.mode === EApiFunctionTransactionMode.MANDATORY && !activeEventManager) {
-		throw ErrorException("ApiFunction transaction mode MANDATORY requires an active transaction");
+		const error: Error = ErrorException("ApiFunction transaction mode MANDATORY requires an active transaction");
+
+		await options.onPreflightError?.(undefined, error);
+
+		throw error;
 	}
 
 	const eventManager: EntityManager | undefined = options.mode === EApiFunctionTransactionMode.NONE ? undefined : activeEventManager;
 
 	if (options.mode === EApiFunctionTransactionMode.REQUIRED && !eventManager) {
+		if (!options.repository) {
+			const error: Error = ErrorException("Repository is not available in this context");
+
+			await options.onPreflightError?.(undefined, error);
+
+			throw error;
+		}
+
 		return await options.repository.manager.transaction(async (transactionManager: EntityManager): Promise<R> => await ApiFunctionTransactionScope.runWithEntityManager(transactionManager, async (): Promise<R> => await options.callback(transactionManager)));
 	}
 

--- a/test/e2e/app/generated-transaction/controller.ts
+++ b/test/e2e/app/generated-transaction/controller.ts
@@ -1,0 +1,46 @@
+import { Inject } from "@nestjs/common";
+
+import { ApiController, ApiControllerSecurable, EApiAuthenticationType, EApiAuthorizationMode, EApiRouteType } from "../../../../src/index";
+
+import { TestAuthGuard } from "../auth-guard";
+import { E2eEntity } from "../entity";
+import { E2eGeneratedTransactionService } from "./service";
+
+const authentication = {
+	guard: TestAuthGuard,
+	type: EApiAuthenticationType.USER,
+};
+
+@ApiControllerSecurable()
+@ApiController<E2eEntity>({
+	authorization: {
+		defaultMode: EApiAuthorizationMode.HOOKS,
+	},
+	entity: E2eEntity,
+	name: "E2eGeneratedTransactionEntities",
+	path: "generated-transaction-items",
+	routes: {
+		[EApiRouteType.CREATE]: {
+			security: { authentication },
+		},
+		[EApiRouteType.DELETE]: {
+			generation: { isEnabled: false },
+		},
+		[EApiRouteType.GET]: {
+			generation: { isEnabled: false },
+		},
+		[EApiRouteType.GET_LIST]: {
+			generation: { isEnabled: false },
+		},
+		[EApiRouteType.PARTIAL_UPDATE]: {
+			generation: { isEnabled: false },
+		},
+		[EApiRouteType.UPDATE]: {
+			generation: { isEnabled: false },
+		},
+	},
+})
+export class E2eGeneratedTransactionController {
+	@Inject(E2eGeneratedTransactionService)
+	public readonly service!: E2eGeneratedTransactionService;
+}

--- a/test/e2e/app/generated-transaction/index.ts
+++ b/test/e2e/app/generated-transaction/index.ts
@@ -1,0 +1,2 @@
+export { E2eGeneratedTransactionController } from "./controller";
+export { E2eGeneratedTransactionService } from "./service";

--- a/test/e2e/app/generated-transaction/service.ts
+++ b/test/e2e/app/generated-transaction/service.ts
@@ -1,0 +1,23 @@
+import type { Repository } from "typeorm";
+
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+
+import { ApiService, ApiServiceBase, ApiServiceObservable, EApiFunctionTransactionMode, EApiFunctionType } from "../../../../src/index";
+
+import { E2eEntity } from "../entity";
+
+@Injectable()
+@ApiServiceObservable()
+@ApiService({
+	entity: E2eEntity,
+	functions: {
+		[EApiFunctionType.CREATE]: {
+			transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+		},
+	},
+})
+export class E2eGeneratedTransactionService extends ApiServiceBase<E2eEntity> {
+	@InjectRepository(E2eEntity)
+	public readonly repository!: Repository<E2eEntity>;
+}

--- a/test/e2e/app/index.ts
+++ b/test/e2e/app/index.ts
@@ -7,6 +7,7 @@ export { E2eController } from "./controller";
 export { E2eEntity } from "./entity";
 export { E2eAppModule } from "./module";
 export * from "./function";
+export * from "./generated-transaction";
 export * from "./manual";
 export * from "./owner";
 export { E2ePolicySubscriber } from "./policy";

--- a/test/e2e/app/module.ts
+++ b/test/e2e/app/module.ts
@@ -12,6 +12,7 @@ import { TestAuthGuard } from "./auth-guard";
 import { E2eController } from "./controller";
 import { E2eEntity } from "./entity";
 import { E2eFunctionController } from "./function";
+import { E2eGeneratedTransactionController, E2eGeneratedTransactionService } from "./generated-transaction";
 import { e2eHookPermissionSource } from "./hook-permission-source";
 import { E2eManualController } from "./manual";
 import { E2eOwnerController, E2eOwnerEntity, E2eOwnerPolicySubscriber, E2eOwnerService } from "./owner";
@@ -23,7 +24,7 @@ import { E2eTransformerErrorController } from "./transformer-error";
 import { E2eValidationPipe } from "./validation-pipe";
 
 @Module({
-	controllers: [E2eController, E2eCustomResponseController, E2eCustomItemResponseController, E2eCustomRouteController, E2eFunctionController, E2eBrokenController, E2eCopyController, E2eManualController, E2eTransformerErrorController, E2eOwnerController],
+	controllers: [E2eController, E2eCustomResponseController, E2eCustomItemResponseController, E2eCustomRouteController, E2eFunctionController, E2eGeneratedTransactionController, E2eBrokenController, E2eCopyController, E2eManualController, E2eTransformerErrorController, E2eOwnerController],
 	imports: [
 		TypeOrmModule.forRoot({
 			database: ":memory:",
@@ -46,6 +47,7 @@ import { E2eValidationPipe } from "./validation-pipe";
 			useClass: E2eValidationPipe,
 		},
 		E2eService,
+		E2eGeneratedTransactionService,
 		E2eOwnerService,
 		E2eBrokenService,
 		TestAuthGuard,

--- a/test/e2e/http/crud.e2e.test.ts
+++ b/test/e2e/http/crud.e2e.test.ts
@@ -401,6 +401,22 @@ describe("CRUD routes (E2E)", () => {
 		expect(E2eFunctionSubscriber.events).toContain("function:before:create:transaction");
 	});
 
+	it("uses configured transactions for generated create routes", async () => {
+		const createResponse = await fastify.inject({
+			headers: adminHeaders,
+			method: "POST",
+			payload: { id: "generated-transaction", name: "GeneratedTransaction", count: 1, ownerId: E2E_OWNER_ID },
+			url: "/generated-transaction-items",
+		});
+
+		expect(createResponse.statusCode).toBe(201);
+		expect(E2eFunctionSubscriber.events).toContain("function:before:create:transaction");
+		expect(await service.repository.findOne({ where: { id: "generated-transaction" } })).toMatchObject({
+			id: "generated-transaction",
+			name: "fn-GeneratedTransaction",
+		});
+	});
+
 	it("uses declared ApiMethod actions for custom securable routes", async () => {
 		await createItem({ id: "item-promote", name: "Promote", count: 1 });
 

--- a/test/unit/decorator/api/service/decorator.test.ts
+++ b/test/unit/decorator/api/service/decorator.test.ts
@@ -1,5 +1,10 @@
 import { ApiService } from "@decorator/api/service/decorator";
-import { describe, expect, it, vi } from "vitest";
+import { ApiFunctionTransactionScope } from "@class/api/function/transaction-scope.class";
+import { ApiServiceBase } from "@class/api/service-base.class";
+import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";
+import { EApiFunctionTransactionMode, EApiFunctionType, EApiSubscriberOnType } from "@enum/decorator/api";
+import type { EntityManager } from "typeorm";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 class ServiceEntity {
 	public id!: string;
@@ -8,6 +13,10 @@ class ServiceEntity {
 }
 
 describe("ApiService", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("wires CRUD methods to repository operations", async () => {
 		type TRepository = {
 			save: (entity: Partial<ServiceEntity>) => Promise<ServiceEntity>;
@@ -65,7 +74,7 @@ describe("ApiService", () => {
 
 		const deleted = await service.delete({ id: "id-1" });
 		expect(repository.remove).toHaveBeenCalledWith(expect.objectContaining({ id: "id-1" }));
-		expect(deleted).toMatchObject({ id: "id-1" });
+		expect(deleted).toBeUndefined();
 	});
 
 	it("does not override existing instance methods", async () => {
@@ -104,5 +113,307 @@ describe("ApiService", () => {
 		expect(customGetList).toHaveBeenCalled();
 		expect(repository.save).not.toHaveBeenCalled();
 		expect(repository.findAndCount).not.toHaveBeenCalled();
+	});
+
+	it("does not override existing prototype methods", async () => {
+		const repository = {
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity }) as ServiceEntity),
+		};
+		const customCreate = vi.fn(async (_entity: Partial<ServiceEntity>) => {
+			void _entity;
+
+			return { id: "prototype-custom" } as ServiceEntity;
+		});
+
+		@ApiService({ entity: ServiceEntity })
+		class CustomService {
+			public constructor(public repository: unknown) {}
+
+			public async create(entity: Partial<ServiceEntity>): Promise<ServiceEntity> {
+				return await customCreate(entity);
+			}
+		}
+
+		const service = new CustomService(repository) as CustomService & Record<string, any>;
+		const created = await service.create({ id: "id-1" });
+
+		expect(created).toMatchObject({ id: "prototype-custom" });
+		expect(customCreate).toHaveBeenCalledWith({ id: "id-1" });
+		expect(repository.save).not.toHaveBeenCalled();
+	});
+
+	it("does not override inherited prototype methods", async () => {
+		const repository = {
+			remove: vi.fn(async (entity: ServiceEntity) => entity),
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity }) as ServiceEntity),
+		};
+		const customCreate = vi.fn(async (_entity: Partial<ServiceEntity>) => {
+			void _entity;
+
+			return { id: "inherited-create" } as ServiceEntity;
+		});
+		const customDelete = vi.fn(async (_criteria: Partial<ServiceEntity>) => {
+			void _criteria;
+
+			return { id: "inherited-delete" } as ServiceEntity;
+		});
+
+		class BaseService {
+			public constructor(public repository: unknown) {}
+
+			public async create(entity: Partial<ServiceEntity>): Promise<ServiceEntity> {
+				return await customCreate(entity);
+			}
+
+			public async delete(criteria: Partial<ServiceEntity>): Promise<ServiceEntity> {
+				return await customDelete(criteria);
+			}
+		}
+
+		@ApiService({ entity: ServiceEntity })
+		class CustomService extends BaseService {}
+
+		const service = new CustomService(repository) as CustomService & Record<string, any>;
+		const created = await service.create({ id: "id-1" });
+		const deleted = await service.delete({ id: "id-1" });
+
+		expect(created).toMatchObject({ id: "inherited-create" });
+		expect(deleted).toMatchObject({ id: "inherited-delete" });
+		expect(customCreate).toHaveBeenCalledWith({ id: "id-1" });
+		expect(customDelete).toHaveBeenCalledWith({ id: "id-1" });
+		expect(repository.save).not.toHaveBeenCalled();
+		expect(repository.remove).not.toHaveBeenCalled();
+	});
+
+	it("defines generated methods over ApiServiceBase stubs", async () => {
+		const repository = {
+			manager: {
+				transaction: vi.fn(),
+			},
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity, id: "generated" }) as ServiceEntity),
+		};
+
+		vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockResolvedValue(undefined);
+
+		@ApiService({ entity: ServiceEntity })
+		class Service extends ApiServiceBase<ServiceEntity> {
+			public constructor(public repository: unknown) {
+				super();
+			}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+		const created = await service.create({ name: "created" });
+
+		expect(repository.save).toHaveBeenCalledWith({ name: "created" });
+		expect(created).toMatchObject({ id: "generated", name: "created" });
+	});
+
+	it("keeps generated create non-transactional by default", async () => {
+		const repository = {
+			manager: {
+				transaction: vi.fn(),
+			},
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity }) as ServiceEntity),
+		};
+
+		vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockResolvedValue(undefined);
+
+		@ApiService({ entity: ServiceEntity })
+		class Service {
+			public constructor(public repository: unknown) {}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+		const created = await service.create({ id: "id-1", name: "created", count: 1 });
+
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
+		expect(repository.save).toHaveBeenCalledWith({ id: "id-1", name: "created", count: 1 });
+		expect(created).toMatchObject({ id: "id-1", name: "created" });
+	});
+
+	it("opens transactions for configured generated create functions", async () => {
+		const eventRepository = {
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity, id: "event" }) as ServiceEntity),
+		};
+		const eventManager = {
+			getRepository: vi.fn(() => eventRepository),
+		};
+		const repository = {
+			manager: {
+				transaction: vi.fn(async (callback: (manager: typeof eventManager) => Promise<ServiceEntity>) => await callback(eventManager)),
+			},
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity, id: "repo" }) as ServiceEntity),
+		};
+
+		vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockResolvedValue(undefined);
+
+		@ApiService({
+			entity: ServiceEntity,
+			functions: {
+				[EApiFunctionType.CREATE]: {
+					transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+				},
+			},
+		})
+		class Service {
+			public constructor(public repository: unknown) {}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+		const created = await service.create({ name: "created", count: 1 });
+
+		expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+		expect(eventManager.getRepository).toHaveBeenCalledWith(ServiceEntity);
+		expect(eventRepository.save).toHaveBeenCalledWith({ name: "created", count: 1 });
+		expect(repository.save).not.toHaveBeenCalled();
+		expect(created).toMatchObject({ id: "event", name: "created" });
+	});
+
+	it("opens one transaction for configured generated update functions including internal get", async () => {
+		const existingEntity: ServiceEntity = { count: 1, id: "id-1", name: "existing" };
+		const eventRepository = {
+			findOne: vi.fn(async () => existingEntity),
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity }) as ServiceEntity),
+		};
+		const eventManager = {
+			getRepository: vi.fn(() => eventRepository),
+		};
+		const repository = {
+			findOne: vi.fn(async () => existingEntity),
+			manager: {
+				transaction: vi.fn(async (callback: (manager: typeof eventManager) => Promise<ServiceEntity>) => await callback(eventManager)),
+			},
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity, id: "repo" }) as ServiceEntity),
+		};
+
+		vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockResolvedValue(undefined);
+
+		@ApiService({
+			entity: ServiceEntity,
+			functions: {
+				[EApiFunctionType.UPDATE]: {
+					transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+				},
+			},
+		})
+		class Service {
+			public constructor(public repository: unknown) {}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+		const updated = await service.update({ id: "id-1" }, { name: "updated" });
+
+		expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+		expect(eventManager.getRepository).toHaveBeenCalledWith(ServiceEntity);
+		expect(eventRepository.findOne).toHaveBeenCalledWith({ where: { id: "id-1" } });
+		expect(eventRepository.save).toHaveBeenCalledWith(expect.objectContaining({ id: "id-1", name: "updated" }));
+		expect(repository.findOne).not.toHaveBeenCalled();
+		expect(repository.save).not.toHaveBeenCalled();
+		expect(updated).toMatchObject({ id: "id-1", name: "updated" });
+	});
+
+	it("opens one transaction for configured generated delete functions including internal get", async () => {
+		const existingEntity: ServiceEntity = { count: 1, id: "id-1", name: "existing" };
+		const eventRepository = {
+			findOne: vi.fn(async () => existingEntity),
+			remove: vi.fn(async (entity: ServiceEntity) => entity),
+		};
+		const eventManager = {
+			getRepository: vi.fn(() => eventRepository),
+		};
+		const repository = {
+			findOne: vi.fn(async () => existingEntity),
+			manager: {
+				transaction: vi.fn(async (callback: (manager: typeof eventManager) => Promise<unknown>) => await callback(eventManager)),
+			},
+			remove: vi.fn(async (entity: ServiceEntity) => entity),
+		};
+
+		vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockResolvedValue(undefined);
+
+		@ApiService({
+			entity: ServiceEntity,
+			functions: {
+				[EApiFunctionType.DELETE]: {
+					transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+				},
+			},
+		})
+		class Service {
+			public constructor(public repository: unknown) {}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+		const deleted = await service.delete({ id: "id-1" });
+
+		expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+		expect(eventManager.getRepository).toHaveBeenCalledWith(ServiceEntity);
+		expect(eventRepository.findOne).toHaveBeenCalledWith({ where: { id: "id-1" } });
+		expect(eventRepository.remove).toHaveBeenCalledWith(existingEntity);
+		expect(repository.findOne).not.toHaveBeenCalled();
+		expect(repository.remove).not.toHaveBeenCalled();
+		expect(deleted).toBeUndefined();
+	});
+
+	it("fires before_error for generated mandatory transaction preflight failures", async () => {
+		const repository = {
+			manager: {
+				transaction: vi.fn(),
+			},
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity }) as ServiceEntity),
+		};
+		const errorSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers").mockResolvedValue(undefined);
+
+		@ApiService({
+			entity: ServiceEntity,
+			functions: {
+				[EApiFunctionType.CREATE]: {
+					transaction: { mode: EApiFunctionTransactionMode.MANDATORY },
+				},
+			},
+		})
+		class Service {
+			public constructor(public repository: unknown) {}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+
+		await expect(service.create({ name: "created" })).rejects.toThrow("ApiFunction transaction mode MANDATORY requires an active transaction");
+		expect(errorSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(ServiceEntity), EApiFunctionType.CREATE, EApiSubscriberOnType.BEFORE_ERROR, expect.any(Object), expect.any(Error));
+		expect(repository.save).not.toHaveBeenCalled();
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
+	});
+
+	it("fires before_error for generated none transaction preflight failures", async () => {
+		const repository = {
+			manager: {
+				transaction: vi.fn(),
+			},
+			save: vi.fn(async (entity: Partial<ServiceEntity>) => ({ ...entity }) as ServiceEntity),
+		};
+		const errorSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers").mockResolvedValue(undefined);
+		const eventManager = {
+			getRepository: vi.fn(),
+		} as unknown as EntityManager;
+
+		@ApiService({
+			entity: ServiceEntity,
+			functions: {
+				[EApiFunctionType.CREATE]: {
+					transaction: { mode: EApiFunctionTransactionMode.NONE },
+				},
+			},
+		})
+		class Service {
+			public constructor(public repository: unknown) {}
+		}
+
+		const service = new Service(repository) as Service & Record<string, any>;
+
+		await expect(ApiFunctionTransactionScope.runWithEntityManager(eventManager, async () => await service.create({ name: "created" }))).rejects.toThrow("ApiFunction transaction mode NONE cannot run inside an active transaction");
+		expect(errorSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(ServiceEntity), EApiFunctionType.CREATE, EApiSubscriberOnType.BEFORE_ERROR, expect.any(Object), expect.any(Error));
+		expect(repository.save).not.toHaveBeenCalled();
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
 	});
 });

--- a/test/unit/utility/api/controller/get-list/transform/filter.utility.test.ts
+++ b/test/unit/utility/api/controller/get-list/transform/filter.utility.test.ts
@@ -4,12 +4,14 @@ import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
 
 import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
-import { EApiPropertyDescribeType } from "@enum/decorator/api";
+import { EApiDtoType, EApiPropertyDescribeType, EApiRouteType } from "@enum/decorator/api";
 import { EFilterOperation } from "@enum/filter";
 import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
 import { ApiControllerGetListTransformFilter } from "@utility/api/controller/get-list/transform/filter.utility";
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 import { describe, expect, it } from "vitest";
+
+import { OwnerGroupEntity, OwnerMetadata } from "./fixture/owner";
 
 @Entity("owners")
 class OwnerEntity {
@@ -26,6 +28,35 @@ class OwnerEntity {
 	} as TApiPropertyDescribeProperties)
 	@Column({ type: "varchar" })
 	public name!: string;
+
+	@ApiPropertyDescribe({
+		type: EApiPropertyDescribeType.STRING,
+		description: "hidden owner name",
+		properties: {
+			[EApiRouteType.GET_LIST]: {
+				[EApiDtoType.QUERY]: {
+					isEnabled: false,
+				},
+			},
+		},
+	} as TApiPropertyDescribeProperties)
+	@Column({ type: "varchar" })
+	public hiddenName!: string;
+
+	@ApiPropertyDescribe({
+		type: EApiPropertyDescribeType.OBJECT,
+		dataType: OwnerMetadata,
+		description: "owner metadata",
+	} as TApiPropertyDescribeProperties)
+	@Column({ type: "json", nullable: true })
+	public metadata?: OwnerMetadata;
+
+	@ManyToOne(() => OwnerGroupEntity)
+	@ApiPropertyDescribe({
+		type: EApiPropertyDescribeType.RELATION,
+		description: "owner group",
+	} as TApiPropertyDescribeProperties)
+	public group!: OwnerGroupEntity;
 }
 
 @Entity("items")
@@ -111,6 +142,22 @@ describe("ApiControllerGetListTransformFilter", () => {
 			"owner.name..deep[value]": "Owner",
 			"owner.name.deep[operator]": EFilterOperation.EQ,
 			"owner.name.deep[value]": "Owner",
+		};
+
+		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);
+
+		expect(filter).not.toHaveProperty("owner");
+	});
+
+	it("ignores related object, relation, and hidden query fields", () => {
+		const metadata = GenerateEntityInformation<ItemEntity>(ItemEntity as unknown as IApiBaseEntity);
+		const query = {
+			"owner.group[operator]": EFilterOperation.EQ,
+			"owner.group[value]": "group-1",
+			"owner.hiddenName[operator]": EFilterOperation.EQ,
+			"owner.hiddenName[value]": "Hidden",
+			"owner.metadata[operator]": EFilterOperation.EQ,
+			"owner.metadata[value]": "Metadata",
 		};
 
 		const filter = ApiControllerGetListTransformFilter<ItemEntity>(query, metadata);

--- a/test/unit/utility/api/controller/get-list/transform/fixture/owner/group-entity.class.ts
+++ b/test/unit/utility/api/controller/get-list/transform/fixture/owner/group-entity.class.ts
@@ -1,0 +1,15 @@
+import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
+
+import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
+import { EApiPropertyDescribeType } from "@enum/decorator/api";
+import { Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity("owner_groups")
+export class OwnerGroupEntity {
+	@PrimaryGeneratedColumn("uuid")
+	@ApiPropertyDescribe({
+		type: EApiPropertyDescribeType.UUID,
+		description: "owner group id",
+	} as TApiPropertyDescribeProperties)
+	public id!: string;
+}

--- a/test/unit/utility/api/controller/get-list/transform/fixture/owner/index.ts
+++ b/test/unit/utility/api/controller/get-list/transform/fixture/owner/index.ts
@@ -1,0 +1,2 @@
+export { OwnerGroupEntity } from "./group-entity.class";
+export { OwnerMetadata } from "./metadata.class";

--- a/test/unit/utility/api/controller/get-list/transform/fixture/owner/metadata.class.ts
+++ b/test/unit/utility/api/controller/get-list/transform/fixture/owner/metadata.class.ts
@@ -1,0 +1,3 @@
+export class OwnerMetadata {
+	public note?: string;
+}

--- a/test/unit/utility/dto/generate/core.utility.test.ts
+++ b/test/unit/utility/dto/generate/core.utility.test.ts
@@ -2,13 +2,14 @@ import "reflect-metadata";
 
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { ClassConstructor } from "class-transformer";
+import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
 
 import { ApiPropertyEnum } from "@decorator/api/property/enum.decorator";
 import { ApiPropertyObject } from "@decorator/api/property/object.decorator";
 import { ApiPropertyString } from "@decorator/api/property/string.decorator";
 import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
 import { EApiDtoType, EApiPropertyDateIdentifier, EApiPropertyDateType, EApiPropertyDescribeType, EApiPropertyNumberType, EApiPropertyStringType, EApiRouteType } from "@enum/decorator/api";
-import { EFilterOperationString, EFilterOperationUuid } from "@enum/filter";
+import { EFilterOperation, EFilterOperationString, EFilterOperationUuid } from "@enum/filter";
 import { DECORATORS } from "@nestjs/swagger/dist/constants";
 import { DtoGenerate } from "@utility/dto/generate/core.utility";
 import { GenerateEntityInformation } from "@utility/generate-entity-information.utility";
@@ -16,6 +17,8 @@ import { instanceToPlain, plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 import { describe, expect, it } from "vitest";
+
+import { DtoRelatedGroupEntity, DtoRelatedMetaInfo } from "./fixture/dto-related";
 
 enum TestStatus {
 	ACTIVE = "ACTIVE",
@@ -114,6 +117,40 @@ class DtoRelatedEntity {
 		type: EApiPropertyDescribeType.STRING,
 	})
 	public name!: string;
+
+	@Column({ type: "varchar" })
+	@ApiPropertyDescribe({
+		description: "hidden owner name",
+		format: EApiPropertyStringType.STRING,
+		maxLength: 50,
+		minLength: 1,
+		pattern: "/^.+$/",
+		properties: {
+			[EApiRouteType.GET_LIST]: {
+				[EApiDtoType.QUERY]: {
+					isEnabled: false,
+				},
+			},
+		},
+		type: EApiPropertyDescribeType.STRING,
+	} as TApiPropertyDescribeProperties)
+	public hiddenName!: string;
+
+	@Column({ type: "json", nullable: true })
+	// eslint-disable-next-line @elsikora/typescript/no-explicit-any
+	@ApiPropertyDescribe({
+		dataType: DtoRelatedMetaInfo,
+		description: "owner metadata",
+		type: EApiPropertyDescribeType.OBJECT,
+	} as any)
+	public metadata?: DtoRelatedMetaInfo;
+
+	@ManyToOne(() => DtoRelatedGroupEntity)
+	@ApiPropertyDescribe({
+		description: "owner group",
+		type: EApiPropertyDescribeType.RELATION,
+	})
+	public group!: DtoRelatedGroupEntity;
 }
 
 class MetaInfo {
@@ -328,12 +365,28 @@ describe("DtoGenerate", () => {
 		expect(queryInstance && "owner.name[value]" in queryInstance).toBe(true);
 		expect(queryInstance && "owner.name[values]" in queryInstance).toBe(true);
 		expect(queryInstance && "owner.name[operator]" in queryInstance).toBe(true);
+		expect(queryInstance && "owner.group[value]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner.group[operator]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner.hiddenName[value]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner.hiddenName[operator]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner.metadata[value]" in queryInstance).toBe(false);
+		expect(queryInstance && "owner.metadata[operator]" in queryInstance).toBe(false);
 
 		const ownerIdOperatorMetadata = queryDto ? Reflect.getMetadata(DECORATORS.API_MODEL_PROPERTIES, queryDto.prototype, "owner.id[operator]") : undefined;
 		const ownerNameOperatorMetadata = queryDto ? Reflect.getMetadata(DECORATORS.API_MODEL_PROPERTIES, queryDto.prototype, "owner.name[operator]") : undefined;
 
 		expect(ownerIdOperatorMetadata?.enum).toEqual(Object.values(EFilterOperationUuid));
 		expect(ownerNameOperatorMetadata?.enum).toEqual(Object.values(EFilterOperationString));
+
+		const invalidQuery = queryDto
+			? plainToInstance(queryDto as ClassConstructor<unknown>, {
+					"owner.id[operator]": EFilterOperation.CONT,
+					"owner.id[value]": "owner-1",
+				})
+			: undefined;
+		const invalidQueryErrors = invalidQuery ? validateSync(invalidQuery as object) : [];
+
+		expect(invalidQueryErrors.some((error) => error.property === "owner.id[operator]")).toBe(true);
 	});
 
 	it("serializes nested manual DTOs in response mode without manual isResponse", () => {

--- a/test/unit/utility/dto/generate/fixture/dto-related/group-entity.class.ts
+++ b/test/unit/utility/dto/generate/fixture/dto-related/group-entity.class.ts
@@ -1,0 +1,13 @@
+import { ApiPropertyDescribe } from "@decorator/api/property/describe.decorator";
+import { EApiPropertyDescribeType } from "@enum/decorator/api";
+import { Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity("dto_related_groups")
+export class DtoRelatedGroupEntity {
+	@PrimaryGeneratedColumn("uuid")
+	@ApiPropertyDescribe({
+		description: "id",
+		type: EApiPropertyDescribeType.UUID,
+	})
+	public id!: string;
+}

--- a/test/unit/utility/dto/generate/fixture/dto-related/index.ts
+++ b/test/unit/utility/dto/generate/fixture/dto-related/index.ts
@@ -1,0 +1,2 @@
+export { DtoRelatedGroupEntity } from "./group-entity.class";
+export { DtoRelatedMetaInfo } from "./meta-info.class";

--- a/test/unit/utility/dto/generate/fixture/dto-related/meta-info.class.ts
+++ b/test/unit/utility/dto/generate/fixture/dto-related/meta-info.class.ts
@@ -1,0 +1,3 @@
+export class DtoRelatedMetaInfo {
+	public note?: string;
+}


### PR DESCRIPTION
Allow generated apiservice crud functions to use explicit transaction modes. Keep relation filters and docs aligned with the generated dto contract.