### PR TITLE
Enhance CRUD filtering, transactions, and subscriber typing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run type check
+        run: npm run lint:types
+
       - name: Run unit tests
         run: npm run test:unit
 

--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,24 @@ IApiSubscriberFunctionExecutionContext<User, TApiFunctionCreateProperties<User>,
 TApiSubscriberFunctionBeforeCreateContext<User>;
 ```
 
+Before function helper types also accept an optional `Result` generic for advanced subscribers that work with a stricter application-defined service payload. Define this payload type yourself to match the service input shape; the generic only narrows TypeScript's `context.result` type and does not change validation, transformation, or runtime behavior.
+
+```typescript
+type WithdrawalCreateInput = {
+	amount: string;
+	currency: { id: string };
+};
+
+class WithdrawalSubscriber extends ApiFunctionSubscriberBase<Withdrawal, WithdrawalCreateInput> {
+	async onBeforeCreate(context: TApiSubscriberFunctionBeforeCreateContext<Withdrawal, WithdrawalCreateInput>): Promise<WithdrawalCreateInput> {
+		context.result.amount; // string
+		context.result.currency.id; // string
+
+		return context.result;
+	}
+}
+```
+
 **Available helper types:**
 
 - Function subscribers: `TApiSubscriberFunctionBeforeCreateContext`, `TApiSubscriberFunctionAfterCreateContext`, etc.

--- a/ai/crud-automator/examples.md
+++ b/ai/crud-automator/examples.md
@@ -193,3 +193,18 @@ export class PostSlugSubscriber extends ApiFunctionSubscriberBase<PostEntity> {
 	}
 }
 ```
+
+For a generated create flow with a stricter application-defined service payload, pass it as the second generic to both the base class and before-context helper. Define the payload type yourself; the generic only narrows TypeScript's `context.result` type and does not change validation, transformation, or runtime behavior.
+
+```ts
+type PostCreateInput = {
+	title: string;
+	author: { id: string };
+};
+
+export class PostCreateSubscriber extends ApiFunctionSubscriberBase<PostEntity, PostCreateInput> {
+	async onBeforeCreate(context: TApiSubscriberFunctionBeforeCreateContext<PostEntity, PostCreateInput>): Promise<PostCreateInput> {
+		return context.result;
+	}
+}
+```

--- a/docs/api-reference/classes/page.mdx
+++ b/docs/api-reference/classes/page.mdx
@@ -113,6 +113,22 @@ Abstract base class for function-level subscribers.
 
 **Location:** `src/class/api/subscriber/function-base.class.ts`
 
+**Generic Parameters:**
+
+```typescript
+ApiFunctionSubscriberBase<
+	E extends IApiBaseEntity,
+	BeforeCreateResult extends TApiFunctionCreateProperties<E> = TApiFunctionCreateProperties<E>,
+	BeforeDeleteResult extends TApiFunctionDeleteCriteria<E> = TApiFunctionDeleteCriteria<E>,
+	BeforeGetResult extends TApiFunctionGetProperties<E> = TApiFunctionGetProperties<E>,
+	BeforeGetListResult extends TApiFunctionGetListProperties<E> = TApiFunctionGetListProperties<E>,
+	BeforeGetManyResult extends TApiFunctionGetManyProperties<E> = TApiFunctionGetManyProperties<E>,
+	BeforeUpdateResult extends TApiFunctionUpdateProperties<E> = TApiFunctionUpdateProperties<E>,
+>
+```
+
+The before-result generics are optional and type-only. Keep the one-generic form for default CRUD payloads, or pass a stricter before-create payload as `ApiFunctionSubscriberBase<Entity, CreateInput>`.
+
 **Hook Methods:**
 
 - `onBeforeCreate`, `onAfterCreate`, `onBeforeErrorCreate`, `onAfterErrorCreate`

--- a/docs/api-reference/interfaces/page.mdx
+++ b/docs/api-reference/interfaces/page.mdx
@@ -181,29 +181,39 @@ interface IApiSubscriberRoute<E> {
 }
 ```
 
-### IApiSubscriberFunction\<E\>
+### IApiSubscriberFunction\<E, ...BeforeResult\>
 
 Interface for function subscribers.
 
 ```typescript
-interface IApiSubscriberFunction<E> {
+interface IApiSubscriberFunction<
+	E extends IApiBaseEntity,
+	BeforeCreateResult extends TApiFunctionCreateProperties<E> = TApiFunctionCreateProperties<E>,
+	BeforeDeleteResult extends TApiFunctionDeleteCriteria<E> = TApiFunctionDeleteCriteria<E>,
+	BeforeGetResult extends TApiFunctionGetProperties<E> = TApiFunctionGetProperties<E>,
+	BeforeGetListResult extends TApiFunctionGetListProperties<E> = TApiFunctionGetListProperties<E>,
+	BeforeGetManyResult extends TApiFunctionGetManyProperties<E> = TApiFunctionGetManyProperties<E>,
+	BeforeUpdateResult extends TApiFunctionUpdateProperties<E> = TApiFunctionUpdateProperties<E>,
+> {
 	onBeforeCustom?(context: IApiSubscriberFunctionExecutionContext<E, unknown, IApiSubscriberFunctionExecutionContextData<E>>): Promise<unknown>;
 	onAfterCustom?(context: IApiSubscriberFunctionExecutionContext<E, unknown, IApiSubscriberFunctionExecutionContextData<E>>): Promise<unknown>;
-	onBeforeCreate?(context: TApiSubscriberFunctionBeforeCreateContext<E>): Promise<TApiFunctionCreateProperties<E> | undefined>;
+	onBeforeCreate?(context: TApiSubscriberFunctionBeforeCreateContext<E, BeforeCreateResult>): Promise<BeforeCreateResult | undefined>;
 	onAfterCreate?(context: TApiSubscriberFunctionAfterCreateContext<E>): Promise<E | undefined>;
-	onBeforeGet?(context: TApiSubscriberFunctionBeforeGetContext<E>): Promise<TApiFunctionGetProperties<E> | undefined>;
+	onBeforeGet?(context: TApiSubscriberFunctionBeforeGetContext<E, BeforeGetResult>): Promise<BeforeGetResult | undefined>;
 	onAfterGet?(context: TApiSubscriberFunctionAfterGetContext<E>): Promise<E | undefined>;
-	onBeforeGetList?(context: TApiSubscriberFunctionBeforeGetListContext<E>): Promise<TApiFunctionGetListProperties<E> | undefined>;
+	onBeforeGetList?(context: TApiSubscriberFunctionBeforeGetListContext<E, BeforeGetListResult>): Promise<BeforeGetListResult | undefined>;
 	onAfterGetList?(context: TApiSubscriberFunctionAfterGetListContext<E>): Promise<IApiGetListResponseResult<E> | undefined>;
-	onBeforeGetMany?(context: TApiSubscriberFunctionBeforeGetManyContext<E>): Promise<TApiFunctionGetManyProperties<E> | undefined>;
+	onBeforeGetMany?(context: TApiSubscriberFunctionBeforeGetManyContext<E, BeforeGetManyResult>): Promise<BeforeGetManyResult | undefined>;
 	onAfterGetMany?(context: TApiSubscriberFunctionAfterGetManyContext<E>): Promise<Array<E> | undefined>;
-	onBeforeUpdate?(context: TApiSubscriberFunctionBeforeUpdateContext<E>): Promise<TApiFunctionUpdateProperties<E> | undefined>;
+	onBeforeUpdate?(context: TApiSubscriberFunctionBeforeUpdateContext<E, BeforeUpdateResult>): Promise<BeforeUpdateResult | undefined>;
 	onAfterUpdate?(context: TApiSubscriberFunctionAfterUpdateContext<E>): Promise<E | undefined>;
-	onBeforeDelete?(context: TApiSubscriberFunctionBeforeDeleteContext<E>): Promise<TApiFunctionDeleteCriteria<E> | undefined>;
+	onBeforeDelete?(context: TApiSubscriberFunctionBeforeDeleteContext<E, BeforeDeleteResult>): Promise<BeforeDeleteResult | undefined>;
 	onAfterDelete?(context: TApiSubscriberFunctionAfterDeleteContext<E>): Promise<E | undefined>;
 	// ... before/after error hooks include CRUD, GET_MANY, and CUSTOM operations.
 }
 ```
+
+The extra before-result generics are optional and type-only. Use them when a function subscriber has a stricter payload type than the default operation payload; they do not infer DTOs or change runtime behavior.
 
 ## Function Context Interfaces
 

--- a/docs/api-reference/types/page.mdx
+++ b/docs/api-reference/types/page.mdx
@@ -31,7 +31,7 @@ HTTP list queries use lowercase sort directions: `asc` and `desc`.
 ## Subscriber Context Helpers
 
 ```typescript
-type TApiSubscriberFunctionBeforeCreateContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionCreateProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+type TApiSubscriberFunctionBeforeCreateContext<E extends IApiBaseEntity, Result extends TApiFunctionCreateProperties<E> = TApiFunctionCreateProperties<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;
 
 type TApiSubscriberRouteBeforeCreateContext<E extends IApiBaseEntity> = IApiSubscriberRouteExecutionContext<
 	E,
@@ -45,7 +45,7 @@ type TApiSubscriberRouteBeforeCreateContext<E extends IApiBaseEntity> = IApiSubs
 >;
 ```
 
-Prefer the exported helper types over manually spelling every generic parameter.
+Prefer the exported helper types over manually spelling every generic parameter. Before function helpers accept an optional constrained `Result` generic for advanced cases where `context.result` is a stricter application payload. This is type-only and does not change validation, transformation, or runtime behavior.
 
 ## Authorization Types
 

--- a/docs/subscriber-system/execution-context/page.mdx
+++ b/docs/subscriber-system/execution-context/page.mdx
@@ -25,21 +25,39 @@ async onBeforeCreate(
 }
 ```
 
+Before function helpers default to the operation payload type, and can accept a second constrained `Result` generic when a subscriber needs a stricter payload. Define the payload type yourself to match the service input shape; the generic only narrows TypeScript's `context.result` type and does not change validation, transformation, or runtime behavior.
+
+```typescript
+type PostCreateInput = {
+	title: string;
+	author: { id: string };
+};
+
+async onBeforeCreate(
+  context: TApiSubscriberFunctionBeforeCreateContext<PostEntity, PostCreateInput>
+): Promise<PostCreateInput> {
+  context.result.title; // string
+  context.result.author.id; // string
+
+  return context.result;
+}
+```
+
 ### Available Helper Types
 
 **Function Subscribers:**
 
-- `TApiSubscriberFunctionBeforeCreateContext<E>`
+- `TApiSubscriberFunctionBeforeCreateContext<E, Result = TApiFunctionCreateProperties<E>>`
 - `TApiSubscriberFunctionAfterCreateContext<E>`
-- `TApiSubscriberFunctionBeforeUpdateContext<E>`
+- `TApiSubscriberFunctionBeforeUpdateContext<E, Result = TApiFunctionUpdateProperties<E>>`
 - `TApiSubscriberFunctionAfterUpdateContext<E>`
-- `TApiSubscriberFunctionBeforeGetContext<E>`
+- `TApiSubscriberFunctionBeforeGetContext<E, Result = TApiFunctionGetProperties<E>>`
 - `TApiSubscriberFunctionAfterGetContext<E>`
-- `TApiSubscriberFunctionBeforeGetListContext<E>`
+- `TApiSubscriberFunctionBeforeGetListContext<E, Result = TApiFunctionGetListProperties<E>>`
 - `TApiSubscriberFunctionAfterGetListContext<E>`
-- `TApiSubscriberFunctionBeforeGetManyContext<E>`
+- `TApiSubscriberFunctionBeforeGetManyContext<E, Result = TApiFunctionGetManyProperties<E>>`
 - `TApiSubscriberFunctionAfterGetManyContext<E>`
-- `TApiSubscriberFunctionBeforeDeleteContext<E>`
+- `TApiSubscriberFunctionBeforeDeleteContext<E, Result = TApiFunctionDeleteCriteria<E>>`
 - `TApiSubscriberFunctionAfterDeleteContext<E>`
 
 **Route Subscribers:**
@@ -372,8 +390,11 @@ IApiGetListResponseResult<E>;
 // Get many operation (function + route after)
 Array<E>;
 
-// Delete operation (function)
-E; // The deleted entity
+// Delete before hook (function)
+TApiFunctionDeleteCriteria<E>;
+
+// Delete after hook (function)
+E;
 ```
 
 Route before hooks receive request payloads (`body`, `parameters`, `query`) rather than entities, so their `result` shape is based on the incoming DTO. After/error hooks also receive the last request payload on `context.DATA` (when available).

--- a/docs/subscriber-system/function-subscribers/page.mdx
+++ b/docs/subscriber-system/function-subscribers/page.mdx
@@ -57,6 +57,25 @@ private generateSlug(title: string): string {
 }
 ```
 
+For generated create flows that have a stricter application-defined service payload than `DeepPartial<E>`, pass that payload as the second generic. Define the payload type yourself to match the service input shape; the generic only narrows TypeScript's `context.result` type and does not change validation, transformation, or runtime behavior.
+
+```typescript
+type PostCreateInput = {
+	title: string;
+	content: string;
+	author: { id: string };
+};
+
+export class PostCreateSubscriber extends ApiFunctionSubscriberBase<PostEntity, PostCreateInput> {
+	async onBeforeCreate(context: TApiSubscriberFunctionBeforeCreateContext<PostEntity, PostCreateInput>): Promise<PostCreateInput> {
+		context.result.title; // string
+		context.result.author.id; // string
+
+		return context.result;
+	}
+}
+```
+
 #### `onBeforeUpdate`
 
 ```typescript
@@ -407,7 +426,7 @@ export class VersionHistorySubscriber extends ApiFunctionSubscriberBase<PostEnti
 @ApiFunctionSubscriber({ entity: PostEntity, priority: 100 })
 export class DataValidationSubscriber extends ApiFunctionSubscriberBase<PostEntity> {
 	async onBeforeCreate(context: TApiSubscriberFunctionBeforeCreateContext<PostEntity>): Promise<TApiFunctionCreateProperties<PostEntity>> {
-		const { body } = context.result;
+		const body = context.result;
 
 		// Validate content length
 		if (body.content && body.content.length < 100) {

--- a/src/class/api/subscriber/function-base.class.ts
+++ b/src/class/api/subscriber/function-base.class.ts
@@ -1,5 +1,6 @@
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { IApiSubscriberFunction } from "@interface/class/api/subscriber/function.interface";
+import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
 
 import { ApiSubscriberBase } from "./base.class";
 
@@ -8,4 +9,14 @@ import { ApiSubscriberBase } from "./base.class";
  * @see {@link https://elsikora.com/docs/nestjs-crud-automator/api-reference/classes#apifunctionsubscriberbase | API Reference - ApiFunctionSubscriberBase}
  * @see {@link https://elsikora.com/docs/nestjs-crud-automator/subscriber-system/function-subscribers | Subscriber System - Function Subscribers}
  */
-export abstract class ApiFunctionSubscriberBase<E extends IApiBaseEntity> extends ApiSubscriberBase implements IApiSubscriberFunction<E> {}
+export abstract class ApiFunctionSubscriberBase<
+	E extends IApiBaseEntity,
+	BeforeCreateResult extends TApiFunctionCreateProperties<E> = TApiFunctionCreateProperties<E>,
+	BeforeDeleteResult extends TApiFunctionDeleteCriteria<E> = TApiFunctionDeleteCriteria<E>,
+	BeforeGetResult extends TApiFunctionGetProperties<E> = TApiFunctionGetProperties<E>,
+	BeforeGetListResult extends TApiFunctionGetListProperties<E> = TApiFunctionGetListProperties<E>,
+	BeforeGetManyResult extends TApiFunctionGetManyProperties<E> = TApiFunctionGetManyProperties<E>,
+	BeforeUpdateResult extends TApiFunctionUpdateProperties<E> = TApiFunctionUpdateProperties<E>,
+>
+	extends ApiSubscriberBase
+	implements IApiSubscriberFunction<E, BeforeCreateResult, BeforeDeleteResult, BeforeGetResult, BeforeGetListResult, BeforeGetManyResult, BeforeUpdateResult> {}

--- a/src/interface/class/api/subscriber/function.interface.ts
+++ b/src/interface/class/api/subscriber/function.interface.ts
@@ -6,7 +6,15 @@ import type { IApiSubscriber } from "@interface/class/api/subscriber/interface";
 import type { IApiGetListResponseResult } from "@interface/decorator/api";
 import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
 
-export interface IApiSubscriberFunction<E extends IApiBaseEntity> extends IApiSubscriber {
+export interface IApiSubscriberFunction<
+	E extends IApiBaseEntity,
+	BeforeCreateResult extends TApiFunctionCreateProperties<E> = TApiFunctionCreateProperties<E>,
+	BeforeDeleteResult extends TApiFunctionDeleteCriteria<E> = TApiFunctionDeleteCriteria<E>,
+	BeforeGetResult extends TApiFunctionGetProperties<E> = TApiFunctionGetProperties<E>,
+	BeforeGetListResult extends TApiFunctionGetListProperties<E> = TApiFunctionGetListProperties<E>,
+	BeforeGetManyResult extends TApiFunctionGetManyProperties<E> = TApiFunctionGetManyProperties<E>,
+	BeforeUpdateResult extends TApiFunctionUpdateProperties<E> = TApiFunctionUpdateProperties<E>,
+> extends IApiSubscriber {
 	onAfterCreate?(context: IApiSubscriberFunctionExecutionContext<E, E, IApiSubscriberFunctionExecutionContextData<E>>): Promise<E | undefined>;
 	onAfterCustom?(context: IApiSubscriberFunctionExecutionContext<E, unknown, IApiSubscriberFunctionExecutionContextData<E>>): Promise<unknown>;
 	onAfterDelete?(context: IApiSubscriberFunctionExecutionContext<E, E, IApiSubscriberFunctionExecutionContextData<E>>): Promise<E | undefined>;
@@ -27,9 +35,9 @@ export interface IApiSubscriberFunction<E extends IApiBaseEntity> extends IApiSu
 	onAfterGetMany?(context: IApiSubscriberFunctionExecutionContext<E, Array<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<Array<E> | undefined>;
 	onAfterUpdate?(context: IApiSubscriberFunctionExecutionContext<E, E, IApiSubscriberFunctionExecutionContextData<E>>): Promise<E | undefined>;
 
-	onBeforeCreate?(context: IApiSubscriberFunctionExecutionContext<E, TApiFunctionCreateProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<TApiFunctionCreateProperties<E> | undefined>;
+	onBeforeCreate?(context: IApiSubscriberFunctionExecutionContext<E, BeforeCreateResult, IApiSubscriberFunctionExecutionContextData<E>>): Promise<BeforeCreateResult | undefined>;
 	onBeforeCustom?(context: IApiSubscriberFunctionExecutionContext<E, unknown, IApiSubscriberFunctionExecutionContextData<E>>): Promise<unknown>;
-	onBeforeDelete?(context: IApiSubscriberFunctionExecutionContext<E, TApiFunctionDeleteCriteria<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<TApiFunctionDeleteCriteria<E> | undefined>;
+	onBeforeDelete?(context: IApiSubscriberFunctionExecutionContext<E, BeforeDeleteResult, IApiSubscriberFunctionExecutionContextData<E>>): Promise<BeforeDeleteResult | undefined>;
 	onBeforeErrorCreate?(context: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>>, error: Error): Promise<void>;
 	onBeforeErrorCustom?(context: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>>, error: Error): Promise<void>;
 	onBeforeErrorDelete?(context: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>>, error: Error): Promise<void>;
@@ -37,8 +45,8 @@ export interface IApiSubscriberFunction<E extends IApiBaseEntity> extends IApiSu
 	onBeforeErrorGetList?(context: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>>, error: Error): Promise<void>;
 	onBeforeErrorGetMany?(context: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>>, error: Error): Promise<void>;
 	onBeforeErrorUpdate?(context: IApiSubscriberFunctionErrorExecutionContext<E, IApiSubscriberFunctionExecutionContextData<E>>, error: Error): Promise<void>;
-	onBeforeGet?(context: IApiSubscriberFunctionExecutionContext<E, TApiFunctionGetProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<TApiFunctionGetProperties<E> | undefined>;
-	onBeforeGetList?(context: IApiSubscriberFunctionExecutionContext<E, TApiFunctionGetListProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<TApiFunctionGetListProperties<E> | undefined>;
-	onBeforeGetMany?(context: IApiSubscriberFunctionExecutionContext<E, TApiFunctionGetManyProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<TApiFunctionGetManyProperties<E> | undefined>;
-	onBeforeUpdate?(context: IApiSubscriberFunctionExecutionContext<E, TApiFunctionUpdateProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>): Promise<TApiFunctionUpdateProperties<E> | undefined>;
+	onBeforeGet?(context: IApiSubscriberFunctionExecutionContext<E, BeforeGetResult, IApiSubscriberFunctionExecutionContextData<E>>): Promise<BeforeGetResult | undefined>;
+	onBeforeGetList?(context: IApiSubscriberFunctionExecutionContext<E, BeforeGetListResult, IApiSubscriberFunctionExecutionContextData<E>>): Promise<BeforeGetListResult | undefined>;
+	onBeforeGetMany?(context: IApiSubscriberFunctionExecutionContext<E, BeforeGetManyResult, IApiSubscriberFunctionExecutionContextData<E>>): Promise<BeforeGetManyResult | undefined>;
+	onBeforeUpdate?(context: IApiSubscriberFunctionExecutionContext<E, BeforeUpdateResult, IApiSubscriberFunctionExecutionContextData<E>>): Promise<BeforeUpdateResult | undefined>;
 }

--- a/src/type/class/api/subscriber/function/before/create-context.type.ts
+++ b/src/type/class/api/subscriber/function/before/create-context.type.ts
@@ -3,4 +3,4 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/api/subscriber/function/execution/context.interface";
 import type { TApiFunctionCreateProperties } from "@type/decorator/api/function";
 
-export type TApiSubscriberFunctionBeforeCreateContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionCreateProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+export type TApiSubscriberFunctionBeforeCreateContext<E extends IApiBaseEntity, Result extends TApiFunctionCreateProperties<E> = TApiFunctionCreateProperties<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;

--- a/src/type/class/api/subscriber/function/before/delete-context.type.ts
+++ b/src/type/class/api/subscriber/function/before/delete-context.type.ts
@@ -3,4 +3,4 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/api/subscriber/function/execution/context.interface";
 import type { TApiFunctionDeleteCriteria } from "@type/decorator/api/function";
 
-export type TApiSubscriberFunctionBeforeDeleteContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionDeleteCriteria<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+export type TApiSubscriberFunctionBeforeDeleteContext<E extends IApiBaseEntity, Result extends TApiFunctionDeleteCriteria<E> = TApiFunctionDeleteCriteria<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;

--- a/src/type/class/api/subscriber/function/before/get/context.type.ts
+++ b/src/type/class/api/subscriber/function/before/get/context.type.ts
@@ -3,4 +3,4 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/api/subscriber/function/execution/context.interface";
 import type { TApiFunctionGetProperties } from "@type/decorator/api/function";
 
-export type TApiSubscriberFunctionBeforeGetContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionGetProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+export type TApiSubscriberFunctionBeforeGetContext<E extends IApiBaseEntity, Result extends TApiFunctionGetProperties<E> = TApiFunctionGetProperties<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;

--- a/src/type/class/api/subscriber/function/before/get/list-context.type.ts
+++ b/src/type/class/api/subscriber/function/before/get/list-context.type.ts
@@ -3,4 +3,4 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/api/subscriber/function/execution/context.interface";
 import type { TApiFunctionGetListProperties } from "@type/decorator/api/function";
 
-export type TApiSubscriberFunctionBeforeGetListContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionGetListProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+export type TApiSubscriberFunctionBeforeGetListContext<E extends IApiBaseEntity, Result extends TApiFunctionGetListProperties<E> = TApiFunctionGetListProperties<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;

--- a/src/type/class/api/subscriber/function/before/get/many-context.type.ts
+++ b/src/type/class/api/subscriber/function/before/get/many-context.type.ts
@@ -3,4 +3,4 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/api/subscriber/function/execution/context.interface";
 import type { TApiFunctionGetManyProperties } from "@type/decorator/api/function";
 
-export type TApiSubscriberFunctionBeforeGetManyContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionGetManyProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+export type TApiSubscriberFunctionBeforeGetManyContext<E extends IApiBaseEntity, Result extends TApiFunctionGetManyProperties<E> = TApiFunctionGetManyProperties<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;

--- a/src/type/class/api/subscriber/function/before/update-context.type.ts
+++ b/src/type/class/api/subscriber/function/before/update-context.type.ts
@@ -3,4 +3,4 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/api/subscriber/function/execution/context.interface";
 import type { TApiFunctionUpdateProperties } from "@type/decorator/api/function";
 
-export type TApiSubscriberFunctionBeforeUpdateContext<E extends IApiBaseEntity> = IApiSubscriberFunctionExecutionContext<E, TApiFunctionUpdateProperties<E>, IApiSubscriberFunctionExecutionContextData<E>>;
+export type TApiSubscriberFunctionBeforeUpdateContext<E extends IApiBaseEntity, Result extends TApiFunctionUpdateProperties<E> = TApiFunctionUpdateProperties<E>> = IApiSubscriberFunctionExecutionContext<E, Result, IApiSubscriberFunctionExecutionContextData<E>>;

--- a/test/unit/type/class/api/subscriber/function/context-result-generics.test.ts
+++ b/test/unit/type/class/api/subscriber/function/context-result-generics.test.ts
@@ -1,0 +1,122 @@
+import type { IApiSubscriberFunctionExecutionContextData } from "@interface/class/api/subscriber/function/execution";
+import type { IApiSubscriberFunction } from "@interface/class/api/subscriber/function.interface";
+import type { TApiSubscriberFunctionBeforeCreateContext, TApiSubscriberFunctionBeforeDeleteContext, TApiSubscriberFunctionBeforeGetContext, TApiSubscriberFunctionBeforeGetListContext, TApiSubscriberFunctionBeforeGetManyContext, TApiSubscriberFunctionBeforeUpdateContext } from "@type/class/api/subscriber/function";
+import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
+import type { Repository } from "typeorm";
+
+import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";
+import { apiSubscriberRegistry } from "@class/api/subscriber/registry.class";
+import { EApiFunctionType } from "@enum/decorator/api/function-type.enum";
+import { EApiSubscriberOnType } from "@enum/decorator/api/on-type.enum";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { SubscriberResultCreateSubscriber, SubscriberResultEntity, SubscriberResultService, type TSubscriberResultCreateInput, type TSubscriberResultDeleteInput, type TSubscriberResultGetInput, type TSubscriberResultGetListInput, type TSubscriberResultGetManyInput, type TSubscriberResultUpdateInput } from "./fixture";
+
+const resetSubscriberRegistry = (): void => {
+	const registry = apiSubscriberRegistry as unknown as {
+		FUNCTION_SUBSCRIBERS: { clear: () => void };
+		ROUTE_SUBSCRIBERS: { clear: () => void };
+	};
+
+	registry.FUNCTION_SUBSCRIBERS.clear();
+	registry.ROUTE_SUBSCRIBERS.clear();
+};
+
+function createBeforeCreateContext<Result extends TApiFunctionCreateProperties<SubscriberResultEntity>>(result: Result): TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity, Result> {
+	return {
+		DATA: {
+			repository: {} as Repository<SubscriberResultEntity>,
+		},
+		ENTITY: new SubscriberResultEntity(),
+		FUNCTION_TYPE: EApiFunctionType.CREATE,
+		result,
+	};
+}
+
+function createCustomPayload(): TSubscriberResultCreateInput {
+	return {
+		amount: "10.50",
+		currency: {
+			id: "currency-id",
+		},
+		destination: "wallet",
+		ipAddress: null,
+		payWayProvider: {
+			id: "provider-id",
+		},
+		user: {
+			id: "user-id",
+		},
+		userAgent: "vitest",
+	};
+}
+
+describe("function subscriber result generics", () => {
+	beforeEach(() => {
+		resetSubscriberRegistry();
+	});
+
+	it("should keep one-generic create context usage typed as default create properties", () => {
+		const context: TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity> = createBeforeCreateContext({
+			amount: "10.50",
+		});
+
+		expectTypeOf(context.result).toEqualTypeOf<TApiFunctionCreateProperties<SubscriberResultEntity>>();
+		expectTypeOf(context.result.amount).toEqualTypeOf<string | undefined>();
+		expect(context.result.amount).toBe("10.50");
+	});
+
+	it("should strongly type custom create context result payloads", () => {
+		const context: TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity, TSubscriberResultCreateInput> = createBeforeCreateContext(createCustomPayload());
+
+		expectTypeOf(context.result.amount).toEqualTypeOf<string>();
+		expectTypeOf(context.result.currency.id).toEqualTypeOf<string>();
+		expect(context.result.currency.id).toBe("currency-id");
+	});
+
+	it("should expose default and custom result generics for every before helper", () => {
+		expectTypeOf<TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity>["result"]>().toEqualTypeOf<TApiFunctionCreateProperties<SubscriberResultEntity>>();
+		expectTypeOf<TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity, TSubscriberResultCreateInput>["result"]>().toEqualTypeOf<TSubscriberResultCreateInput>();
+		expectTypeOf<TApiSubscriberFunctionBeforeDeleteContext<SubscriberResultEntity>["result"]>().toEqualTypeOf<TApiFunctionDeleteCriteria<SubscriberResultEntity>>();
+		expectTypeOf<TApiSubscriberFunctionBeforeDeleteContext<SubscriberResultEntity, TSubscriberResultDeleteInput>["result"]>().toEqualTypeOf<TSubscriberResultDeleteInput>();
+		expectTypeOf<TApiSubscriberFunctionBeforeGetContext<SubscriberResultEntity>["result"]>().toEqualTypeOf<TApiFunctionGetProperties<SubscriberResultEntity>>();
+		expectTypeOf<TApiSubscriberFunctionBeforeGetContext<SubscriberResultEntity, TSubscriberResultGetInput>["result"]>().toEqualTypeOf<TSubscriberResultGetInput>();
+		expectTypeOf<TApiSubscriberFunctionBeforeGetListContext<SubscriberResultEntity>["result"]>().toEqualTypeOf<TApiFunctionGetListProperties<SubscriberResultEntity>>();
+		expectTypeOf<TApiSubscriberFunctionBeforeGetListContext<SubscriberResultEntity, TSubscriberResultGetListInput>["result"]>().toEqualTypeOf<TSubscriberResultGetListInput>();
+		expectTypeOf<TApiSubscriberFunctionBeforeGetManyContext<SubscriberResultEntity>["result"]>().toEqualTypeOf<TApiFunctionGetManyProperties<SubscriberResultEntity>>();
+		expectTypeOf<TApiSubscriberFunctionBeforeGetManyContext<SubscriberResultEntity, TSubscriberResultGetManyInput>["result"]>().toEqualTypeOf<TSubscriberResultGetManyInput>();
+		expectTypeOf<TApiSubscriberFunctionBeforeUpdateContext<SubscriberResultEntity>["result"]>().toEqualTypeOf<TApiFunctionUpdateProperties<SubscriberResultEntity>>();
+		expectTypeOf<TApiSubscriberFunctionBeforeUpdateContext<SubscriberResultEntity, TSubscriberResultUpdateInput>["result"]>().toEqualTypeOf<TSubscriberResultUpdateInput>();
+	});
+
+	it("should reject custom result generics that are not assignable to the operation payload", () => {
+		// @ts-expect-error Result must remain assignable to TApiFunctionCreateProperties<SubscriberResultEntity>.
+		const invalidCreateContext: TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity, { readonly amount: number }> = undefined as never;
+		// @ts-expect-error IApiSubscriberFunction uses the same constrained before-create result generic.
+		const invalidCreateSubscriber: IApiSubscriberFunction<SubscriberResultEntity, { readonly amount: number }> = undefined as never;
+
+		expect(invalidCreateContext).toBeUndefined();
+		expect(invalidCreateSubscriber).toBeUndefined();
+	});
+
+	it("should allow function subscriber contracts to return a custom create result", async () => {
+		const subscriber: IApiSubscriberFunction<SubscriberResultEntity, TSubscriberResultCreateInput> = new SubscriberResultCreateSubscriber();
+		const result = await subscriber.onBeforeCreate?.(createBeforeCreateContext(createCustomPayload()));
+
+		expectTypeOf(result).toEqualTypeOf<TSubscriberResultCreateInput | undefined>();
+		expect(result?.user.id).toBe("user-id");
+	});
+
+	it("should preserve executor generic result type through registered subscriber dispatch", async () => {
+		const subscriber = new SubscriberResultCreateSubscriber();
+		const hookSpy = vi.spyOn(subscriber, "onBeforeCreate");
+
+		apiSubscriberRegistry.registerFunctionSubscriber({ entity: SubscriberResultEntity }, subscriber);
+
+		const result = await ApiSubscriberExecutor.executeFunctionSubscribers<SubscriberResultEntity, TSubscriberResultCreateInput, IApiSubscriberFunctionExecutionContextData<SubscriberResultEntity>>(SubscriberResultService, new SubscriberResultEntity(), EApiFunctionType.CREATE, EApiSubscriberOnType.BEFORE, createBeforeCreateContext(createCustomPayload()));
+
+		expectTypeOf(result).toEqualTypeOf<TSubscriberResultCreateInput | undefined>();
+		expect(hookSpy).toHaveBeenCalledTimes(1);
+		expect(result?.payWayProvider.id).toBe("provider-id");
+	});
+});

--- a/test/unit/type/class/api/subscriber/function/fixture/create/index.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/create/index.ts
@@ -1,0 +1,2 @@
+export { type TSubscriberResultCreateInput } from "./input.type";
+export { SubscriberResultCreateSubscriber } from "./subscriber.class";

--- a/test/unit/type/class/api/subscriber/function/fixture/create/input.type.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/create/input.type.ts
@@ -1,0 +1,15 @@
+export type TSubscriberResultCreateInput = {
+	readonly amount: string;
+	readonly currency: {
+		readonly id: string;
+	};
+	readonly destination: string;
+	readonly ipAddress: null | string;
+	readonly payWayProvider: {
+		readonly id: string;
+	};
+	readonly user: {
+		readonly id: string;
+	};
+	readonly userAgent: null | string;
+};

--- a/test/unit/type/class/api/subscriber/function/fixture/create/subscriber.class.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/create/subscriber.class.ts
@@ -1,0 +1,13 @@
+import type { TApiSubscriberFunctionBeforeCreateContext } from "@type/class/api/subscriber/function";
+
+import { ApiFunctionSubscriberBase } from "@class/api/subscriber/function-base.class";
+
+import type { TSubscriberResultCreateInput } from "./input.type";
+
+import { SubscriberResultEntity } from "../entity.class";
+
+export class SubscriberResultCreateSubscriber extends ApiFunctionSubscriberBase<SubscriberResultEntity, TSubscriberResultCreateInput> {
+	public async onBeforeCreate(context: TApiSubscriberFunctionBeforeCreateContext<SubscriberResultEntity, TSubscriberResultCreateInput>): Promise<TSubscriberResultCreateInput> {
+		return context.result;
+	}
+}

--- a/test/unit/type/class/api/subscriber/function/fixture/delete/index.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/delete/index.ts
@@ -1,0 +1,1 @@
+export { type TSubscriberResultDeleteInput } from "./input.type";

--- a/test/unit/type/class/api/subscriber/function/fixture/delete/input.type.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/delete/input.type.ts
@@ -1,0 +1,7 @@
+import type { TApiFunctionDeleteCriteria } from "@type/decorator/api/function";
+
+import type { SubscriberResultEntity } from "../entity.class";
+
+export type TSubscriberResultDeleteInput = TApiFunctionDeleteCriteria<SubscriberResultEntity> & {
+	readonly amount: string;
+};

--- a/test/unit/type/class/api/subscriber/function/fixture/entity.class.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/entity.class.ts
@@ -1,0 +1,6 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+
+export class SubscriberResultEntity implements IApiBaseEntity {
+	public amount?: string;
+	public name?: string;
+}

--- a/test/unit/type/class/api/subscriber/function/fixture/get/index.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/get/index.ts
@@ -1,0 +1,3 @@
+export { type TSubscriberResultGetInput } from "./input.type";
+export { type TSubscriberResultGetListInput } from "./list-input.type";
+export { type TSubscriberResultGetManyInput } from "./many-input.type";

--- a/test/unit/type/class/api/subscriber/function/fixture/get/input.type.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/get/input.type.ts
@@ -1,0 +1,9 @@
+import type { TApiFunctionGetProperties } from "@type/decorator/api/function";
+
+import type { SubscriberResultEntity } from "../entity.class";
+
+export type TSubscriberResultGetInput = TApiFunctionGetProperties<SubscriberResultEntity> & {
+	readonly where: {
+		readonly amount: string;
+	};
+};

--- a/test/unit/type/class/api/subscriber/function/fixture/get/list-input.type.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/get/list-input.type.ts
@@ -1,0 +1,7 @@
+import type { TApiFunctionGetListProperties } from "@type/decorator/api/function";
+
+import type { SubscriberResultEntity } from "../entity.class";
+
+export type TSubscriberResultGetListInput = TApiFunctionGetListProperties<SubscriberResultEntity> & {
+	readonly take: 10;
+};

--- a/test/unit/type/class/api/subscriber/function/fixture/get/many-input.type.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/get/many-input.type.ts
@@ -1,0 +1,7 @@
+import type { TApiFunctionGetManyProperties } from "@type/decorator/api/function";
+
+import type { SubscriberResultEntity } from "../entity.class";
+
+export type TSubscriberResultGetManyInput = TApiFunctionGetManyProperties<SubscriberResultEntity> & {
+	readonly take: 10;
+};

--- a/test/unit/type/class/api/subscriber/function/fixture/index.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/index.ts
@@ -1,0 +1,6 @@
+export * from "./create";
+export type * from "./delete";
+export { SubscriberResultEntity } from "./entity.class";
+export type * from "./get";
+export { SubscriberResultService } from "./service.class";
+export type * from "./update";

--- a/test/unit/type/class/api/subscriber/function/fixture/service.class.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/service.class.ts
@@ -1,0 +1,4 @@
+import { ApiServiceObservable } from "@decorator/api/service/observable.decorator";
+
+@ApiServiceObservable()
+export class SubscriberResultService {}

--- a/test/unit/type/class/api/subscriber/function/fixture/update/index.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/update/index.ts
@@ -1,0 +1,1 @@
+export { type TSubscriberResultUpdateInput } from "./input.type";

--- a/test/unit/type/class/api/subscriber/function/fixture/update/input.type.ts
+++ b/test/unit/type/class/api/subscriber/function/fixture/update/input.type.ts
@@ -1,0 +1,7 @@
+import type { TApiFunctionUpdateProperties } from "@type/decorator/api/function";
+
+import type { SubscriberResultEntity } from "../entity.class";
+
+export type TSubscriberResultUpdateInput = TApiFunctionUpdateProperties<SubscriberResultEntity> & {
+	readonly amount: string;
+};

--- a/test/unit/type/class/api/subscriber/function/index.ts
+++ b/test/unit/type/class/api/subscriber/function/index.ts
@@ -1,0 +1,1 @@
+export * from "./fixture";


### PR DESCRIPTION
## Summary
- Add strict dot-path GET_LIST relation filtering and align DTO generation, validation, docs, and tests.
- Allow generated CRUD service functions to configure transaction modes through `@ApiService`.
- Expose constrained before-hook result generics for function subscribers with type-level coverage and docs.

## Test plan
- `npm run lint:types`
- `npm run lint`
- `npm run test:unit`
- `npm run test:e2e`