### PR TITLE
feat(api): align request relation loading with include

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run type check
         run: npm run lint:types
 
+      - name: Run lint
+        run: npm run lint
+
       - name: Run unit tests
         run: npm run test:unit
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The core philosophy of this library is built on four pillars: being **Declarativ
 - ✨ **🧩 Type-safe decorators for entity properties with rich metadata support**
 - ✨ **🔒 Authentication and authorization guards integration**
 - ✨ **🔍 Advanced filtering, sorting, and pagination for list operations**
-- ✨ **📚 Support for object relations with automatic loading strategies**
+- ✨ **📚 Support for object relations with include-driven loading**
 - ✨ **⚡ Performance optimized with TypeORM integration for database operations**
 - ✨ **🌐 Full support for TypeScript with strong typing throughout the library**
 - ✨ **Hooks and Subscriber System:** Intercept and extend business logic at both the controller and service level.
@@ -295,10 +295,10 @@ export class UserController {
 
 ### Handling Relations
 
-Automatically load related entities:
+Configure include-driven relation loading:
 
 ```typescript
-import { ApiController, EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape, EApiRouteType } from "@elsikora/nestjs-crud-automator";
+import { ApiController, EApiControllerRelationReferenceShape, EApiRouteType } from "@elsikora/nestjs-crud-automator";
 
 @ApiController<PostEntity>({
 	entity: PostEntity,
@@ -309,15 +309,15 @@ import { ApiController, EApiControllerLoadRelationsStrategy, EApiControllerRelat
 				request: {
 					reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
 					load: {
-						shouldLoad: true,
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						shouldForceAllServicesToBeSpecified: false,
+						include: { author: true },
 					},
 				},
 				response: {
 					reference: { shape: EApiControllerRelationReferenceShape.OBJECT, key: "id" },
-					load: { include: { author: true, comments: true } },
+					load: {
+						include: { author: true, comments: true },
+						relationLoadStrategy: "query",
+					},
 				},
 			},
 		},
@@ -330,6 +330,8 @@ export class PostController {
 	) {}
 }
 ```
+
+Request relation `relations.request.load` enables hydration, and `relations.request.load.include` selects the direct request body relations to hydrate. Omitted service mappings use `${relationName}Service`; `relations.request.load.services` only overrides those controller property names. Nested request include objects are passed to the direct relation service as TypeORM `relations`; nested request references are not recursively hydrated. `load.relationLoadStrategy` can be used on request or response load configs to choose TypeORM `"join"` or `"query"` loading.
 
 ### Custom DTOs
 
@@ -454,7 +456,7 @@ public promote(@Param("id") id: string) {
 
 The same `metadata.resource.action` value is what hooks receive as `context.action` and what IAM turns into a namespaced action such as `admin:user:update.promote`.
 
-Use `@ApiRouteCustom(...)` when a custom controller route should also participate in the custom route runtime: request/response transformers, route subscribers, relation loading/projection, authorization result transforms, and response serialization. `@ApiMethod(...)` remains the low-level metadata/decorator composer.
+Use `@ApiRouteCustom(...)` when a custom controller route should also participate in the custom route runtime: request/response transformers, route subscribers, relation loading/projection, authorization result transforms, and response serialization. Custom route request relation hydration reads the method body payload; response relation reload requires a controller `service` extending `ApiServiceBase` and response values with an `id`. `@ApiMethod(...)` remains the low-level metadata/decorator composer.
 
 ```typescript
 @ApiRouteCustom<UserEntity>({

--- a/ai/crud-automator/SKILL.md
+++ b/ai/crud-automator/SKILL.md
@@ -61,12 +61,13 @@ Use local source as the contract:
 ## Relation Model
 
 - Request relation config: `relations.request.reference` and `relations.request.load`.
-- Request load config uses `shouldLoad`, `relationStrategy`, `serviceStrategy`, `relations`, `services`, and `shouldForceAllServicesToBeSpecified`.
-- `relations.request.load.relations` only filters loaded relations when `relationStrategy` is `MANUAL`; `services` is only required when `serviceStrategy` is `MANUAL`.
-- Response relation config: `relations.response.reference` and `relations.response.load.include`.
+- Request load config uses `relations.request.load.include`, optional `relations.request.load.relationLoadStrategy`, and optional `relations.request.load.services` overrides.
+- `relations.request.load.include` is the single source of truth for direct request relations to hydrate. Omitted service keys use `${relationName}Service`.
+- Response relation config: `relations.response.reference` and `relations.response.load.include` with optional `relationLoadStrategy`.
 - HTTP generated relation filters use explicit one-level paths such as `author.id[...]` and `author.username[...]`; top-level `author[...]` is not generated or transformed.
 - Generated relation filters skip relation fields and object fields on the related entity.
-- For nested response relations, use TypeORM relation object maps in `response.load.include`.
+- For nested request or response relations, use TypeORM relation object maps in `load.include`.
+- Nested request include objects are only passed to the direct relation service as TypeORM `relations`; nested request references are not recursively hydrated.
 
 ## Subscriber Model
 

--- a/ai/crud-automator/examples.md
+++ b/ai/crud-automator/examples.md
@@ -95,14 +95,15 @@ export class UserController {
 				request: {
 					reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
 					load: {
-						shouldLoad: true,
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
+						include: { author: true },
 					},
 				},
 				response: {
 					reference: { shape: EApiControllerRelationReferenceShape.OBJECT, key: "id" },
-					load: { include: { author: true } },
+					load: {
+						include: { author: true },
+						relationLoadStrategy: "query",
+					},
 				},
 			},
 		},

--- a/ai/crud-automator/pitfalls.md
+++ b/ai/crud-automator/pitfalls.md
@@ -43,9 +43,9 @@ Route before hooks can use `context.result.body`.
 
 ## Relation Load Config Drift
 
-For AUTO relation loading, omit explicit `relations`; AUTO scans relation columns. Use `relations` only with `relationStrategy: MANUAL`, and use `services` only with `serviceStrategy: MANUAL`.
+Use `relations.request.load.include` to select direct request relations to hydrate. Do not use the old request `relations` array or AUTO/MANUAL strategy flags.
 
-Request relation hydration mutates direct relation references into loaded entities. It does not implement nested request relation paths.
+Request relation hydration mutates direct relation references into loaded entities. Nested include objects preload relations on the direct loaded entity; they do not implement recursive nested request reference hydration.
 
 ## Custom Route Runtime Assumptions
 

--- a/ai/crud-automator/reference.md
+++ b/ai/crud-automator/reference.md
@@ -57,14 +57,15 @@ routes: {
 			request: {
 				reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
 				load: {
-					shouldLoad: true,
-					relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-					serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
+					include: { author: true },
 				},
 			},
 			response: {
 				reference: { shape: EApiControllerRelationReferenceShape.OBJECT, key: "id" },
-				load: { include: { author: true } },
+				load: {
+					include: { author: true },
+					relationLoadStrategy: "query",
+				},
 			},
 		},
 	},
@@ -110,9 +111,10 @@ Custom route caveats:
 
 Generated request relation caveats:
 
-- `relations.request.load.relations` is only a filter for `relationStrategy: MANUAL`; omit it for AUTO examples.
-- `relations.request.load.services` is only read when `serviceStrategy: MANUAL`; AUTO expects `<relationName>Service` properties on the controller.
-- Request relation hydration mutates relation references into loaded entity objects and currently handles direct relation properties only.
+- `relations.request.load.include` selects the direct request body relations to hydrate.
+- `relations.request.load.services` is only an override map; omitted keys use `<relationName>Service` properties on the controller.
+- `relations.request.load.relationLoadStrategy` is passed to the direct relation service get call alongside nested TypeORM `relations` when configured.
+- Request relation hydration mutates direct relation references into loaded entity objects. Nested include objects are passed to the direct relation service as TypeORM `relations`; nested request references are not recursively hydrated.
 - For generated routes, request relation hydration reads relation fields from the request body for CREATE, UPDATE, and PARTIAL_UPDATE. It does not hydrate GET/DELETE route parameters.
 - CREATE reloads the created entity with configured response relations. UPDATE/PARTIAL_UPDATE reload only when response relation loading is configured. DELETE returns no body. GET_LIST maps `limit`/`page` to `take`/`skip` and applies `orderBy` only when present.
 

--- a/docs/api-reference/decorators/api-method/api-route-custom/page.mdx
+++ b/docs/api-reference/decorators/api-method/api-route-custom/page.mdx
@@ -137,7 +137,7 @@ Custom route relations live under `relations.request` and `relations.response`, 
 	route: { method: RequestMethod.POST, path: ":id/author" },
 	relations: {
 		request: {
-			load: { shouldLoad: true },
+			load: { include: { author: true } },
 			reference: {
 				key: "id",
 				shape: EApiControllerRelationReferenceShape.OBJECT,
@@ -162,7 +162,9 @@ async assignAuthor(@Body() body: Partial<PostEntity>): Promise<PostEntity> {
 }
 ```
 
-For response relation loading, the route response must identify the entity so the runtime can reload configured relations before projecting them to the configured reference shape.
+For response relation loading, the route response must identify the entity so the runtime can reload configured relations before projecting them to the configured reference shape. The controller must expose `service` extending `ApiServiceBase`; response items without an `id` are returned unchanged.
+
+Custom route request relation hydration reads only the method body payload. `relations.request.load.include` selects direct body relations, nested include objects are passed to the direct relation service as TypeORM `relations`, and nested request references are not recursively hydrated. Omitted service mappings infer `${relationName}Service`; `relations.request.load.services` only overrides those controller property names. `relationLoadStrategy` is available on both request and response `load` configs.
 
 ## Subscribers
 

--- a/docs/api-reference/enums/page.mdx
+++ b/docs/api-reference/enums/page.mdx
@@ -437,21 +437,6 @@ enum EApiControllerResponseTarget {
 }
 ```
 
-### EApiControllerLoadRelationsStrategy
-
-Relation loading strategies.
-
-```typescript
-enum EApiControllerLoadRelationsStrategy {
-	AUTO = "AUTO",
-	MANUAL = "MANUAL",
-}
-```
-
-**Related:**
-
-- [Guides - Relations](/docs/nestjs-crud-automator/guides/relations)
-
 ### EApiControllerRelationReferenceShape
 
 Relation reference shapes used by request hydration and response projection.

--- a/docs/core-concepts/controllers/page.mdx
+++ b/docs/core-concepts/controllers/page.mdx
@@ -216,10 +216,10 @@ routes: {
 
 ## Loading Relations
 
-Configure automatic relation loading:
+Configure relation loading:
 
 ```typescript
-import { EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape } from "@elsikora/nestjs-crud-automator";
+import { EApiControllerRelationReferenceShape } from "@elsikora/nestjs-crud-automator";
 
 @ApiController<PostEntity>({
 	entity: PostEntity,
@@ -229,14 +229,15 @@ import { EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceSha
 				request: {
 					reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
 					load: {
-						shouldLoad: true,
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
+						include: { author: true },
 					},
 				},
 				response: {
 					reference: { shape: EApiControllerRelationReferenceShape.OBJECT, key: "id" },
-					load: { include: { author: true, comments: true } },
+					load: {
+						include: { author: true, comments: true },
+						relationLoadStrategy: "query",
+					},
 				},
 			},
 		},
@@ -251,10 +252,14 @@ export class PostController {
 }
 ```
 
-Strategies:
+Relation loading uses:
 
-- `AUTO` - Automatically detect and load relations
-- `MANUAL` - Explicitly specify which relations to load
+- `load.include` - Select direct relations and nested TypeORM relation preloads.
+- `load.relationLoadStrategy` - Optional TypeORM `"join"` or `"query"` strategy.
+- `relations.request.load.services` - Optional override for direct relation service property names; omitted keys use `${relationName}Service`.
+- Request relation `load` hydrates only direct included relation keys present in the request body. Omitted, `undefined`, and `null` body relation values are left unchanged.
+- Nested request include objects are passed to the direct relation service as TypeORM `relations`; they do not recursively hydrate nested request references.
+- Custom route request relation loading uses the same relation config, but it only hydrates the method `@Body()` argument.
 
 ## Custom DTOs
 

--- a/docs/core-concepts/entities/page.mdx
+++ b/docs/core-concepts/entities/page.mdx
@@ -257,7 +257,7 @@ In this example, generated `ArticleEntity` DTOs include `id`, `slug`, and `title
 
 ### Relation Properties
 
-Entity relationships with automatic loading:
+Entity relationship metadata for route-configured loading:
 
 ```typescript
 @ManyToOne(() => UserEntity, user => user.posts)

--- a/docs/guides/relations/page.mdx
+++ b/docs/guides/relations/page.mdx
@@ -1,6 +1,6 @@
 # Relations
 
-NestJS CRUD Automator supports automatic loading and management of entity relations. Configure relation loading strategies to control how and when related entities are fetched.
+NestJS CRUD Automator supports include-driven request relation hydration and response relation loading. Use `load.include` to select relations and TypeORM `relationLoadStrategy` when you need to control `"join"` vs `"query"` loading.
 
 ## Defining Relations
 
@@ -45,12 +45,12 @@ export class PostEntity {
 
 ## Loading Relations
 
-### Automatic Loading
+### Include-Driven Loading
 
-Configure automatic relation loading in controller routes:
+Configure relation loading in controller routes:
 
 ```typescript filename="post.controller.ts" copy
-import { ApiController, EApiRouteType, EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape } from "@elsikora/nestjs-crud-automator";
+import { ApiController, EApiRouteType, EApiControllerRelationReferenceShape } from "@elsikora/nestjs-crud-automator";
 
 @ApiController<PostEntity>({
 	entity: PostEntity,
@@ -61,14 +61,15 @@ import { ApiController, EApiRouteType, EApiControllerLoadRelationsStrategy, EApi
 				request: {
 					reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
 					load: {
-						shouldLoad: true,
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
+						include: { author: true },
 					},
 				},
 				response: {
 					reference: { shape: EApiControllerRelationReferenceShape.OBJECT, key: "id" },
-					load: { include: { author: true, comments: true } },
+					load: {
+						include: { author: true, comments: true },
+						relationLoadStrategy: "query",
+					},
 				},
 			},
 		},
@@ -90,7 +91,7 @@ export class PostController {
 }
 ```
 
-### Manual Loading
+### Explicit Loading
 
 Specify exactly which relations to load:
 
@@ -101,9 +102,7 @@ routes: {
       request: {
         reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
         load: {
-          shouldLoad: true,
-          relationStrategy: EApiControllerLoadRelationsStrategy.MANUAL,
-          relations: ["author"],
+          include: { author: true },
         },
       },
     },
@@ -111,9 +110,9 @@ routes: {
 }
 ```
 
-### Nested Response Relations
+### Nested Relation Includes
 
-Use nested `response.load.include` objects when a GET/GET_LIST response should include relations of relations. Request-side relation hydration reads direct relation property names from request bodies for CREATE, UPDATE/PARTIAL_UPDATE, and `@ApiRouteCustom` body payloads. It does not hydrate GET/DELETE route parameters.
+Use nested `load.include` objects when request hydration or a GET/GET_LIST response should include relations of relations. Request-side relation hydration reads direct relation property names from request bodies for CREATE, UPDATE/PARTIAL_UPDATE, and `@ApiRouteCustom` body payloads. Nested request include objects are passed to the related service as TypeORM `relations`; they do not recursively hydrate nested request references. Request relation hydration does not hydrate GET/DELETE route parameters.
 
 ```typescript
 routes: {
@@ -128,22 +127,15 @@ routes: {
 }
 ```
 
-## Relation Loading Strategies
+## TypeORM Relation Load Strategy
 
-### `AUTO` Strategy
-
-Automatically detects and loads configured relations:
+Use `relationLoadStrategy` when TypeORM should load configured relations with a specific strategy:
 
 ```typescript
-relationStrategy: EApiControllerLoadRelationsStrategy.AUTO;
-```
-
-### `MANUAL` Strategy
-
-Only loads explicitly specified relations:
-
-```typescript
-relationStrategy: EApiControllerLoadRelationsStrategy.MANUAL;
+load: {
+  include: { author: { profile: true } },
+  relationLoadStrategy: "query", // or "join"
+}
 ```
 
 ## Service Injection for Relations
@@ -160,9 +152,7 @@ Inject related services to enable relation loading:
 				request: {
 					reference: { shape: EApiControllerRelationReferenceShape.SCALAR },
 					load: {
-						shouldLoad: true,
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
+						include: { author: true },
 					},
 				},
 			},
@@ -178,7 +168,7 @@ export class PostController {
 }
 ```
 
-The library uses these injected services to load relations efficiently.
+The library uses these injected services to hydrate request relation references. By default, an included request relation named `author` resolves `authorService` on the controller. Use `relations.request.load.services` only when the controller property name differs, for example `services: { author: "userService" }`.
 
 ## Eager vs Lazy Loading
 
@@ -285,7 +275,7 @@ routes: {
   [EApiRouteType.CREATE]: {
     relations: {
       request: {
-        load: { shouldLoad: true },
+        load: { include: { author: true } },
         reference: {
           key: "code",
           shape: EApiControllerRelationReferenceShape.OBJECT,
@@ -315,7 +305,7 @@ With that configuration, `{ author: { code: "author-001" } }` is validated and h
 	route: { method: RequestMethod.POST, path: ":id/author" },
 	relations: {
 		request: {
-			load: { shouldLoad: true },
+			load: { include: { author: true } },
 			reference: { key: "id", shape: EApiControllerRelationReferenceShape.SCALAR },
 		},
 		response: {
@@ -333,7 +323,7 @@ async assignAuthor(@Body() body: Partial<PostEntity>): Promise<PostEntity> {
 }
 ```
 
-Request relations are hydrated before the handler runs. Response relations can be reloaded and projected for single entities, arrays, and get-list style `{ items }` envelopes. Generated CREATE reloads the created entity with configured response relations; UPDATE and PARTIAL_UPDATE reload only when response relation loading is configured; DELETE returns no response body to project.
+Custom route request relations are hydrated from the method body payload before the handler runs. Response relation reload requires `controller.service` to extend `ApiServiceBase`; response values without an `id` are returned unchanged. Response relations can be reloaded and projected for single entities, arrays, and get-list style `{ items }` envelopes. Generated CREATE reloads the created entity with configured response relations; UPDATE and PARTIAL_UPDATE reload only when response relation loading is configured; DELETE returns no response body to project.
 
 ## Performance Optimization
 

--- a/docs/page.mdx
+++ b/docs/page.mdx
@@ -18,7 +18,7 @@ This library provides a comprehensive suite of decorators, utilities, and valida
 - Type-safe decorators for entity properties
 - Authentication and authorization guards integration
 - Advanced filtering, sorting, and pagination
-- Support for object relations with automatic loading strategies
+- Support for object relations with include-driven loading
 - Subscriber system for intercepting and extending business logic
 - Request tracing with CorrelationID interceptor
 

--- a/src/class/api/route-runtime.class.ts
+++ b/src/class/api/route-runtime.class.ts
@@ -5,7 +5,7 @@ import type { IApiRouteRuntimeContextData, IApiRouteRuntimeCustomExecutionOption
 import type { IApiSubscriberRouteErrorExecutionContext } from "@interface/class/api/subscriber/route/error-execution-context.interface";
 import type { IApiSubscriberRouteExecutionContextData } from "@interface/class/api/subscriber/route/execution/context";
 import type { IApiSubscriberRouteExecutionContext } from "@interface/class/api/subscriber/route/execution/context";
-import type { IApiControllerProperties, IApiControllerPropertiesRouteBaseRequestTarget, IApiRouteMetadata, IApiRouteRuntimeProperties } from "@interface/decorator/api";
+import type { IApiControllerProperties, IApiControllerPropertiesRouteBaseRelationsResponseLoad, IApiControllerPropertiesRouteBaseRequestTarget, IApiRouteMetadata, IApiRouteRuntimeProperties } from "@interface/decorator/api";
 import type { IApiEntity } from "@interface/entity";
 import type { IApiControllerPrimaryColumn } from "@interface/utility";
 import type { Type } from "@nestjs/common";
@@ -114,7 +114,7 @@ export class ApiRouteRuntime {
 	}
 
 	public static async executeCustomResponseRelations<E extends IApiBaseEntity, R>(controller: TApiControllerMethod<E>, runtimeProperties: IApiRouteRuntimeProperties<E>, response: R): Promise<R> {
-		if (!runtimeProperties.relations?.response?.load?.include) {
+		if (!this.hasResponseRelationInclude(runtimeProperties.relations?.response?.load?.include)) {
 			return response;
 		}
 
@@ -278,6 +278,7 @@ export class ApiRouteRuntime {
 				const createResponse: E = await options.controller.service.create((targets.body ?? {}) as never);
 
 				return await options.controller.service.get({
+					relationLoadStrategy: routeConfig.relations?.response?.load?.relationLoadStrategy,
 					relations: routeConfig.relations?.response?.load?.include,
 					where: AuthorizationScopeMergeWhere({ [primaryKey.key]: createResponse[primaryKey.key] } as FindOptionsWhere<E>, authorizationDecision?.scope?.where),
 				});
@@ -300,6 +301,7 @@ export class ApiRouteRuntime {
 				const primaryKey: IApiControllerPrimaryColumn<E> = this.resolvePrimaryKey(targets.parameters, options.entityMetadata);
 
 				const requestProperties: TApiFunctionGetProperties<E> = {
+					relationLoadStrategy: routeConfig.relations?.response?.load?.relationLoadStrategy,
 					relations: routeConfig.relations?.response?.load?.include,
 					where: AuthorizationScopeMergeWhere({ [primaryKey.key]: primaryKey.value } as FindOptionsWhere<E>, authorizationDecision?.scope?.where),
 				};
@@ -322,6 +324,7 @@ export class ApiRouteRuntime {
 				const scopedFilter: Array<TApiFunctionGetListPropertiesWhere<E>> | TApiFunctionGetListPropertiesWhere<E> | undefined = AuthorizationScopeMergeWhere(filter, authorizationDecision?.scope?.where);
 
 				const requestProperties: TApiFunctionGetListProperties<E> = {
+					relationLoadStrategy: routeConfig.relations?.response?.load?.relationLoadStrategy,
 					relations: routeConfig.relations?.response?.load?.include,
 					skip: query.limit * (query.page - 1),
 					take: query.limit,
@@ -398,13 +401,15 @@ export class ApiRouteRuntime {
 		const scopedCriteria: TApiAuthorizationScopeWhere<E> = AuthorizationScopeMergeWhere(requestCriteria, authorizationDecision?.scope?.where);
 		markAfterBoundary();
 		const updateResponse: E = await options.controller.service.update(scopedCriteria ?? requestCriteria, (targets.body ?? {}) as never);
+		const responseLoad: IApiControllerPropertiesRouteBaseRelationsResponseLoad<E> | undefined = routeConfig.relations?.response?.load;
 
-		if (!routeConfig.relations?.response?.load?.include) {
+		if (!responseLoad || !this.hasResponseRelationInclude(responseLoad.include)) {
 			return updateResponse;
 		}
 
 		return await options.controller.service.get({
-			relations: routeConfig.relations.response.load.include,
+			relationLoadStrategy: responseLoad.relationLoadStrategy,
+			relations: responseLoad.include,
 			where: AuthorizationScopeMergeWhere({ [primaryKey.key]: updateResponse[primaryKey.key] } as FindOptionsWhere<E>, authorizationDecision?.scope?.where),
 		});
 	}
@@ -425,6 +430,15 @@ export class ApiRouteRuntime {
 		await this.executeDiscriminatedRequestBodyDto(runtimeProperties, request);
 	}
 
+	/**
+	 * Checks whether response relation loading has at least one configured include key.
+	 * @param {unknown} include - Response include map.
+	 * @returns {boolean} Whether response relation loading should run.
+	 */
+	private static hasResponseRelationInclude(include: unknown): boolean {
+		return include !== null && typeof include === "object" && Object.keys(include).length > 0;
+	}
+
 	private static async loadCustomResponseRelations<E extends IApiBaseEntity>(service: ApiServiceBase<E>, runtimeProperties: IApiRouteRuntimeProperties<E>, response: unknown): Promise<unknown> {
 		if (response === null || typeof response !== "object" || !("id" in response)) {
 			return response;
@@ -437,6 +451,7 @@ export class ApiRouteRuntime {
 		}
 
 		return await service.get({
+			relationLoadStrategy: runtimeProperties.relations?.response?.load?.relationLoadStrategy,
 			relations: runtimeProperties.relations?.response?.load?.include,
 			where: {
 				id: responseId,

--- a/src/enum/decorator/api/controller/index.ts
+++ b/src/enum/decorator/api/controller/index.ts
@@ -1,4 +1,3 @@
-export { EApiControllerLoadRelationsStrategy } from "./load-relations-strategy.enum";
 export { EApiControllerRelationReferenceShape } from "./relation-reference-shape.enum";
 export * from "./request";
 export { EApiControllerResponseTarget } from "./response-target.enum";

--- a/src/enum/decorator/api/controller/load-relations-strategy.enum.ts
+++ b/src/enum/decorator/api/controller/load-relations-strategy.enum.ts
@@ -1,4 +1,0 @@
-export enum EApiControllerLoadRelationsStrategy {
-	AUTO = "AUTO",
-	MANUAL = "MANUAL",
-}

--- a/src/interface/decorator/api/controller/properties/route/base/relations/request/load.interface.ts
+++ b/src/interface/decorator/api/controller/properties/route/base/relations/request/load.interface.ts
@@ -1,11 +1,7 @@
-import type { EApiControllerLoadRelationsStrategy } from "@enum/decorator/api";
-import type { FindOptionsRelations } from "typeorm";
+import type { FindOneOptions, FindOptionsRelations } from "typeorm";
 
 export interface IApiControllerPropertiesRouteBaseRelationsRequestLoad<E> {
-	relations?: Array<keyof FindOptionsRelations<E>>;
-	relationStrategy?: EApiControllerLoadRelationsStrategy;
+	include: FindOptionsRelations<E>;
+	relationLoadStrategy?: FindOneOptions<E>["relationLoadStrategy"];
 	services?: Partial<Record<keyof FindOptionsRelations<E>, string>>;
-	serviceStrategy?: EApiControllerLoadRelationsStrategy;
-	shouldForceAllServicesToBeSpecified?: boolean;
-	shouldLoad: boolean;
 }

--- a/src/interface/decorator/api/controller/properties/route/base/relations/response/load.interface.ts
+++ b/src/interface/decorator/api/controller/properties/route/base/relations/response/load.interface.ts
@@ -1,5 +1,6 @@
-import type { FindOptionsRelations } from "typeorm";
+import type { FindOneOptions, FindOptionsRelations } from "typeorm";
 
 export interface IApiControllerPropertiesRouteBaseRelationsResponseLoad<E> {
 	include?: FindOptionsRelations<E>;
+	relationLoadStrategy?: FindOneOptions<E>["relationLoadStrategy"];
 }

--- a/src/utility/api/controller/handle-request-relations.utility.ts
+++ b/src/utility/api/controller/handle-request-relations.utility.ts
@@ -4,113 +4,215 @@ import type { TApiControllerMethod } from "@type/class";
 import type { TApiControllerGetListQuery } from "@type/decorator/api/controller";
 import type { TApiFunctionGetProperties } from "@type/decorator/api/function";
 import type { TApiServiceKeys } from "@type/decorator/api/service";
-import type { DeepPartial, FindOptionsWhere } from "typeorm";
+import type { DeepPartial, FindOptionsRelations } from "typeorm";
 
 import { ApiServiceBase } from "@class/api/service-base.class";
-import { EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape } from "@enum/decorator/api";
-import { BadRequestException } from "@nestjs/common";
+import { EApiControllerRelationReferenceShape } from "@enum/decorator/api";
+import { EErrorStringAction } from "@enum/utility";
+import { BadRequestException, HttpStatus } from "@nestjs/common";
 import { ErrorException } from "@utility/error/exception.utility";
+import { ErrorString } from "@utility/error/string.utility";
 import { GetEntityColumns } from "@utility/get/entity-columns.utility";
 
 /**
  * Manages loading related entities when processing API requests.
- * Determines which relations to load based on configuration strategy (MANUAL or AUTO),
+ * Determines which relations to load based on request load include,
  * finds the appropriate service for each relation, and loads the related entities.
  * @param {TApiControllerMethod<E>} controllerMethod - The controller method with access to service instances
  * @param {IApiControllerProperties<E>} properties - Controller configuration properties
  * @param {IApiControllerPropertiesRouteBaseRelationsRequest<E> | undefined} relationConfig - Configuration for relation loading
  * @param {DeepPartial<E> | Partial<E> | TApiControllerGetListQuery<E>} parameters - The request parameters containing relation IDs
  * @returns {Promise<void>} A promise that resolves when all relations are loaded
- * @throws {BadRequestException} When an invalid relation ID is provided
+ * @throws {BadRequestException} When the request relation reference shape is invalid
  * @throws {Error} When service configuration is invalid or services are not found
  * @template E - The entity type
- * @template R - The route type
  */
 export async function ApiControllerHandleRequestRelations<E extends IApiBaseEntity>(controllerMethod: TApiControllerMethod<E>, properties: IApiControllerProperties<E>, relationConfig: IApiControllerPropertiesRouteBaseRelationsRequest<E> | undefined, parameters: DeepPartial<E> | Partial<E> | TApiControllerGetListQuery<E>): Promise<void> {
 	const loadConfig: IApiControllerPropertiesRouteBaseRelationsRequest<E>["load"] | undefined = relationConfig?.load;
 	const referenceConfig: IApiControllerPropertiesRouteBaseRelationsRequest<E>["reference"] | undefined = relationConfig?.reference;
 
-	if (loadConfig?.shouldLoad && referenceConfig) {
-		for (const propertyName of GetEntityColumns<E>({ entity: properties.entity, shouldTakeRelationsOnly: true })) {
-			// @ts-expect-error
-			if (parameters[propertyName] !== undefined && typeof propertyName === "string") {
-				if (loadConfig.relationStrategy === EApiControllerLoadRelationsStrategy.MANUAL && !loadConfig.relations?.includes(propertyName)) {
-					continue;
-				}
+	if (!loadConfig) {
+		return;
+	}
 
-				let serviceName: keyof TApiServiceKeys<E> | undefined;
+	if (!referenceConfig) {
+		throw ErrorException("Request relation reference config is required when relation loading is configured");
+	}
 
-				if (loadConfig.serviceStrategy === EApiControllerLoadRelationsStrategy.MANUAL) {
-					const manualServiceName: unknown = loadConfig.services?.[propertyName];
+	validateReferenceConfig(referenceConfig);
 
-					if (manualServiceName === undefined) {
-						throw ErrorException(`Service name not specified for property ${propertyName} in manual mode`);
-					}
-					serviceName = manualServiceName as keyof TApiServiceKeys<E>;
-				} else {
-					serviceName = `${propertyName}Service` as keyof TApiServiceKeys<E>;
-				}
+	const relationNames: Set<string> = new Set<string>(GetEntityColumns<E>({ entity: properties.entity, shouldTakeRelationsOnly: true }).filter((propertyName: keyof E): propertyName is keyof E & string => typeof propertyName === "string"));
+	const parametersRecord: Record<string, unknown> = parameters as Record<string, unknown>;
 
-				if (!serviceName) {
-					throw ErrorException(`Service name not specified for property ${propertyName}`);
-				}
+	for (const [propertyName, includeValue] of getIncludedRelationEntries(loadConfig.include)) {
+		validateIncludedRelationKey(propertyName, relationNames);
 
-				const service: unknown = controllerMethod[serviceName];
-
-				if (!service) {
-					if ((loadConfig.serviceStrategy === EApiControllerLoadRelationsStrategy.AUTO && loadConfig.shouldForceAllServicesToBeSpecified) || loadConfig.serviceStrategy === EApiControllerLoadRelationsStrategy.MANUAL) {
-						throw ErrorException(`Service ${serviceName as string} not found in controller`);
-					}
-					continue;
-				}
-
-				if (!(service instanceof ApiServiceBase)) {
-					throw ErrorException(`Service ${serviceName as string} is not an instance of BaseApiService`);
-				}
-
-				const referenceKey: string = referenceConfig.key ?? "id";
-				const relationValue: unknown = (parameters as Record<string, unknown>)[propertyName];
-				const referenceValue: unknown = resolveRelationReferenceValue(propertyName, relationValue, referenceConfig.shape, referenceKey);
-
-				const requestProperties: TApiFunctionGetProperties<E> = {
-					where: {
-						[referenceKey]: referenceValue,
-					} as FindOptionsWhere<E>,
-				};
-
-				const entity: E[keyof E & string] = (await service.get(requestProperties)) as E[keyof E & string];
-
-				if (!entity) {
-					throw new BadRequestException(`Invalid ${propertyName} ID`);
-				}
-
-				// @ts-expect-error
-				parameters[propertyName] = entity;
-			}
+		if (!Object.prototype.hasOwnProperty.call(parametersRecord, propertyName) || parametersRecord[propertyName] === undefined || parametersRecord[propertyName] === null || includeValue === false) {
+			continue;
 		}
+
+		const nestedInclude: FindOptionsRelations<IApiBaseEntity> | undefined = resolveNestedInclude(propertyName, includeValue);
+		const serviceName: keyof TApiServiceKeys<E> = resolveRelationServiceName(propertyName, loadConfig.services);
+		const service: unknown = controllerMethod[serviceName];
+
+		if (!service) {
+			throw ErrorException(`Service ${serviceName as string} not found in controller`);
+		}
+
+		if (!(service instanceof ApiServiceBase)) {
+			throw ErrorException(`Service ${serviceName as string} is not an instance of ApiServiceBase`);
+		}
+
+		const referenceKey: string = referenceConfig.key ?? "id";
+		const referenceValue: unknown = resolveRelationReferenceValue(properties.entity, propertyName, parametersRecord[propertyName], referenceConfig.shape, referenceKey);
+
+		const requestProperties: TApiFunctionGetProperties<IApiBaseEntity> = {
+			where: {
+				[referenceKey]: referenceValue,
+			},
+		};
+
+		if (nestedInclude) {
+			requestProperties.relations = nestedInclude;
+		}
+
+		if (loadConfig.relationLoadStrategy) {
+			requestProperties.relationLoadStrategy = loadConfig.relationLoadStrategy;
+		}
+
+		const entity: IApiBaseEntity = await (service as ApiServiceBase<IApiBaseEntity>).get(requestProperties);
+
+		if (!entity) {
+			throw ErrorException(`Service ${serviceName as string} returned an empty relation entity`);
+		}
+
+		parametersRecord[propertyName] = entity;
 	}
 }
 
 /**
+ * Builds a canonical bad request exception for invalid relation references.
+ * @param {IApiBaseEntity} entity - Parent entity metadata.
+ * @param {string} propertyName - Relation property name.
+ * @param {EApiControllerRelationReferenceShape} expectedShape - Expected reference shape.
+ * @param {string} referenceKey - Expected object reference key.
+ * @returns {BadRequestException} Structured bad request exception.
+ */
+function buildRelationReferenceBadRequestException(entity: IApiBaseEntity, propertyName: string, expectedShape: EApiControllerRelationReferenceShape, referenceKey: string): BadRequestException {
+	return new BadRequestException({
+		details: {
+			expectedShape,
+			propertyName,
+			referenceKey,
+		},
+		error: "Bad Request",
+		message: ErrorString({ entity, type: EErrorStringAction.INVALID_REFERENCE }),
+		statusCode: HttpStatus.BAD_REQUEST,
+	});
+}
+
+/**
+ * Returns direct relation include entries from the TypeORM-shaped include map.
+ * @param {unknown} include - Request include map.
+ * @returns {Array<[string, unknown]>} Direct include entries.
+ */
+function getIncludedRelationEntries(include: unknown): Array<[string, unknown]> {
+	if (include === null || typeof include !== "object" || Array.isArray(include)) {
+		throw ErrorException("Request relation load include must be an object");
+	}
+
+	return Object.entries(include as Record<string, unknown>);
+}
+
+/**
+ * Converts a direct include value into nested TypeORM relations for relation service get calls.
+ * @param {string} propertyName - Relation property name.
+ * @param {unknown} includeValue - Direct include value.
+ * @returns {FindOptionsRelations<IApiBaseEntity> | undefined} Nested relation include map.
+ */
+function resolveNestedInclude(propertyName: string, includeValue: unknown): FindOptionsRelations<IApiBaseEntity> | undefined {
+	if (includeValue === true || includeValue === false) {
+		return undefined;
+	}
+
+	if (includeValue === null || typeof includeValue !== "object") {
+		throw ErrorException(`Invalid include value for relation ${propertyName}`);
+	}
+
+	return includeValue;
+}
+
+/**
  * Resolves the relation reference value according to the configured request shape.
- * @param {string} propertyName - Relation property name used in validation messages.
+ * @param {IApiBaseEntity} entity - Parent entity metadata.
+ * @param {string} propertyName - Relation property name used in validation details.
  * @param {unknown} value - Incoming scalar or object reference value.
  * @param {EApiControllerRelationReferenceShape} shape - Expected relation reference shape.
  * @param {string} referenceKey - Property key to read from object references.
  * @returns {unknown} Reference value used to load the related entity.
  */
-function resolveRelationReferenceValue(propertyName: string, value: unknown, shape: EApiControllerRelationReferenceShape, referenceKey: string): unknown {
+function resolveRelationReferenceValue(entity: IApiBaseEntity, propertyName: string, value: unknown, shape: EApiControllerRelationReferenceShape, referenceKey: string): unknown {
 	if (shape === EApiControllerRelationReferenceShape.SCALAR) {
 		if (value !== null && typeof value === "object") {
-			throw new BadRequestException(`Relation ${propertyName} must be a scalar reference`);
+			throw buildRelationReferenceBadRequestException(entity, propertyName, shape, referenceKey);
 		}
 
 		return value;
 	}
 
 	if (value === null || typeof value !== "object" || !(referenceKey in value)) {
-		throw new BadRequestException(`Relation ${propertyName} must be an object reference with "${referenceKey}"`);
+		throw buildRelationReferenceBadRequestException(entity, propertyName, shape, referenceKey);
 	}
 
-	return (value as Record<string, unknown>)[referenceKey];
+	const referenceValue: unknown = (value as Record<string, unknown>)[referenceKey];
+
+	if (referenceValue === null || referenceValue === undefined) {
+		throw buildRelationReferenceBadRequestException(entity, propertyName, shape, referenceKey);
+	}
+
+	return referenceValue;
+}
+
+/**
+ * Resolves the controller property name for a direct request relation service.
+ * @param {string} propertyName - Relation property name.
+ * @param {NonNullable<IApiControllerPropertiesRouteBaseRelationsRequest<E>["load"]>["services"]} services - Optional service override map.
+ * @returns {keyof TApiServiceKeys<E>} Controller service property name.
+ * @template E - Entity type.
+ */
+function resolveRelationServiceName<E extends IApiBaseEntity>(propertyName: string, services: NonNullable<IApiControllerPropertiesRouteBaseRelationsRequest<E>["load"]>["services"]): keyof TApiServiceKeys<E> {
+	const serviceName: string = services?.[propertyName] ?? `${propertyName}Service`;
+
+	if (!serviceName) {
+		throw ErrorException(`Service name not specified for property ${propertyName}`);
+	}
+
+	return serviceName as keyof TApiServiceKeys<E>;
+}
+
+/**
+ * Ensures a configured include key is a direct relation on the entity.
+ * @param {string} propertyName - Include property name.
+ * @param {Set<string>} relationNames - Direct entity relation names.
+ * @returns {void}
+ */
+function validateIncludedRelationKey(propertyName: string, relationNames: Set<string>): void {
+	if (!relationNames.has(propertyName)) {
+		throw ErrorException(`Relation ${propertyName} is not a direct relation on the entity`);
+	}
+}
+
+/**
+ * Ensures request relation reference settings are valid route configuration.
+ * @param {IApiControllerPropertiesRouteBaseRelationsRequest<IApiBaseEntity>["reference"]} referenceConfig - Request relation reference config.
+ * @returns {void}
+ */
+function validateReferenceConfig(referenceConfig: IApiControllerPropertiesRouteBaseRelationsRequest<IApiBaseEntity>["reference"]): void {
+	if (!Object.values(EApiControllerRelationReferenceShape).includes(referenceConfig.shape)) {
+		throw ErrorException("Request relation reference shape must be OBJECT or SCALAR");
+	}
+
+	if (referenceConfig.key?.length === 0) {
+		throw ErrorException("Request relation reference key must not be empty");
+	}
 }

--- a/src/utility/api/route/response/project-relation.utility.ts
+++ b/src/utility/api/route/response/project-relation.utility.ts
@@ -2,6 +2,7 @@ import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { IApiControllerPropertiesRouteBaseRelationsResponse } from "@interface/decorator/api";
 
 import { EApiControllerRelationReferenceShape } from "@enum/decorator/api";
+import { ErrorException } from "@utility/error/exception.utility";
 
 /**
  * Projects loaded relation objects into the configured response reference shape.
@@ -12,40 +13,35 @@ import { EApiControllerRelationReferenceShape } from "@enum/decorator/api";
  * @returns {R} Response value with projected relation references.
  */
 export function ApiRouteProjectRelationResponse<E extends IApiBaseEntity, R>(relationConfig: IApiControllerPropertiesRouteBaseRelationsResponse<E> | undefined, response: R): R {
-	if (!relationConfig?.load?.include) {
+	if (!relationConfig?.load?.include || Object.keys(relationConfig.load.include).length === 0) {
 		return response;
 	}
+
+	validateResponseReferenceConfig(relationConfig.reference);
 
 	const relationNames: Array<string> = Object.keys(relationConfig.load.include);
 	const referenceKey: string = relationConfig.reference.key ?? "id";
 	const responses: Array<Record<string, unknown>> = [];
-	let projectedArray: Array<unknown> | undefined;
 
 	if (Array.isArray(response)) {
-		projectedArray = response.map((item: unknown): unknown => {
+		for (const item of response) {
 			if (item === null || typeof item !== "object") {
-				return item;
+				continue;
 			}
 
-			const projectedItem: Record<string, unknown> = { ...(item as Record<string, unknown>) };
-			responses.push(projectedItem);
-
-			return projectedItem;
-		});
+			responses.push(item as Record<string, unknown>);
+		}
 	} else {
 		const responseValue: unknown = response;
 
 		if (responseValue !== null && typeof responseValue === "object" && "items" in responseValue && Array.isArray((responseValue as { items?: unknown }).items)) {
-			(responseValue as { items: Array<unknown> }).items = (responseValue as { items: Array<unknown> }).items.map((item: unknown): unknown => {
+			for (const item of (responseValue as { items: Array<unknown> }).items) {
 				if (item === null || typeof item !== "object") {
-					return item;
+					continue;
 				}
 
-				const projectedItem: Record<string, unknown> = { ...(item as Record<string, unknown>) };
-				responses.push(projectedItem);
-
-				return projectedItem;
-			});
+				responses.push(item as Record<string, unknown>);
+			}
 		} else if (responseValue !== null && typeof responseValue === "object") {
 			responses.push(responseValue as Record<string, unknown>);
 		}
@@ -64,5 +60,24 @@ export function ApiRouteProjectRelationResponse<E extends IApiBaseEntity, R>(rel
 		}
 	}
 
-	return (projectedArray as R) || response;
+	return response;
+}
+
+/**
+ * Ensures response relation reference settings are valid route configuration.
+ * @param {IApiControllerPropertiesRouteBaseRelationsResponse<IApiBaseEntity>["reference"] | undefined} referenceConfig - Response relation reference config.
+ * @returns {void}
+ */
+function validateResponseReferenceConfig(referenceConfig: IApiControllerPropertiesRouteBaseRelationsResponse<IApiBaseEntity>["reference"] | undefined): void {
+	if (!referenceConfig) {
+		throw ErrorException("Response relation reference config is required when relation loading is configured");
+	}
+
+	if (!Object.values(EApiControllerRelationReferenceShape).includes(referenceConfig.shape)) {
+		throw ErrorException("Response relation reference shape must be OBJECT or SCALAR");
+	}
+
+	if (referenceConfig.key?.length === 0) {
+		throw ErrorException("Response relation reference key must not be empty");
+	}
 }

--- a/test/e2e/app/controller.ts
+++ b/test/e2e/app/controller.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Body, HttpStatus, Inject, Param, RequestMethod } from "@nestjs/common";
 
-import { ApiMethod, EApiAuthenticationType, EApiAuthorizationMode, EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape, EApiControllerRequestTarget, EApiControllerRequestTransformerType, EApiControllerResponseTarget, EApiRouteType, EErrorStringAction, TRANSFORMER_VALUE_DTO_CONSTANT } from "../../../src/index";
+import { ApiMethod, EApiAuthenticationType, EApiAuthorizationMode, EApiControllerRelationReferenceShape, EApiControllerRequestTarget, EApiControllerRequestTransformerType, EApiControllerResponseTarget, EApiRouteType, EErrorStringAction, TRANSFORMER_VALUE_DTO_CONSTANT } from "../../../src/index";
 import { ApiController, ApiControllerObservable, ApiControllerSecurable } from "../../../src/index";
 
 import { TestAuthGuard } from "./auth-guard";
@@ -29,9 +29,7 @@ const authentication = {
 			relations: {
 				request: {
 					load: {
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						shouldLoad: true,
+						include: { owner: true },
 					},
 					reference: {
 						shape: EApiControllerRelationReferenceShape.SCALAR,
@@ -189,9 +187,7 @@ const authentication = {
 			relations: {
 				request: {
 					load: {
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						shouldLoad: true,
+						include: { owner: true },
 					},
 					reference: {
 						key: "id",

--- a/test/e2e/app/custom-route/controller.ts
+++ b/test/e2e/app/custom-route/controller.ts
@@ -139,7 +139,7 @@ export class E2eCustomRouteController {
 		relations: {
 			request: {
 				load: {
-					shouldLoad: true,
+					include: { owner: true },
 				},
 				reference: {
 					key: "id",

--- a/test/e2e/app/manual/controller.ts
+++ b/test/e2e/app/manual/controller.ts
@@ -1,7 +1,7 @@
 import { Inject } from "@nestjs/common";
 
 import { ApiController, ApiControllerObservable, ApiControllerSecurable } from "../../../../src/index";
-import { EApiAuthenticationType, EApiAuthorizationMode, EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape, EApiRouteType } from "../../../../src/index";
+import { EApiAuthenticationType, EApiAuthorizationMode, EApiControllerRelationReferenceShape, EApiRouteType } from "../../../../src/index";
 
 import { TestAuthGuard } from "../auth-guard";
 import { E2eEntity } from "../entity";
@@ -28,13 +28,10 @@ const authentication = {
 			relations: {
 				request: {
 					load: {
-						relationStrategy: EApiControllerLoadRelationsStrategy.MANUAL,
-						relations: ["owner"],
-						serviceStrategy: EApiControllerLoadRelationsStrategy.MANUAL,
+						include: { owner: true },
 						services: {
 							owner: "ownerService",
 						},
-						shouldLoad: true,
 					},
 					reference: {
 						shape: EApiControllerRelationReferenceShape.SCALAR,

--- a/test/e2e/db-backed-iam-consumer.e2e.test.ts
+++ b/test/e2e/db-backed-iam-consumer.e2e.test.ts
@@ -29,7 +29,6 @@ import {
 	EApiAuthenticationType,
 	EApiAuthorizationMode,
 	EApiAuthorizationPrincipalType,
-	EApiControllerLoadRelationsStrategy,
 	EApiControllerRelationReferenceShape,
 	EApiPolicyEffect,
 	EApiPolicySourceType,
@@ -321,9 +320,7 @@ const iamConsumerAuthorization = {
 			relations: {
 				request: {
 					load: {
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						shouldLoad: true,
+						include: { operator: true },
 					},
 					reference: {
 						shape: EApiControllerRelationReferenceShape.SCALAR,
@@ -358,9 +355,7 @@ const iamConsumerAuthorization = {
 			relations: {
 				request: {
 					load: {
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						shouldLoad: true,
+						include: { operator: true },
 					},
 					reference: {
 						shape: EApiControllerRelationReferenceShape.SCALAR,
@@ -373,9 +368,7 @@ const iamConsumerAuthorization = {
 			relations: {
 				request: {
 					load: {
-						relationStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						serviceStrategy: EApiControllerLoadRelationsStrategy.AUTO,
-						shouldLoad: true,
+						include: { operator: true },
 					},
 					reference: {
 						shape: EApiControllerRelationReferenceShape.SCALAR,

--- a/test/e2e/http/crud.e2e.test.ts
+++ b/test/e2e/http/crud.e2e.test.ts
@@ -1490,6 +1490,11 @@ describe("CRUD routes (E2E)", () => {
 		});
 
 		expect(createResponse.statusCode).toBe(400);
+		expect(createResponse.json()).toMatchObject({
+			error: "Bad Request",
+			message: ["owner must be a UUID"],
+			statusCode: 400,
+		});
 	});
 
 	it("validates ApiPropertyCopy body DTOs with class-validator", async () => {
@@ -1511,7 +1516,7 @@ describe("CRUD routes (E2E)", () => {
 		expect(response.json()).toMatchObject({ count: 2, name: "Copied" });
 	});
 
-	it("returns 400 when relation id is invalid", async () => {
+	it("returns 404 when relation id is invalid", async () => {
 		const createResponse = await fastify.inject({
 			headers: adminHeaders,
 			method: "POST",
@@ -1520,6 +1525,11 @@ describe("CRUD routes (E2E)", () => {
 		});
 
 		expect(createResponse.statusCode).toBe(404);
+		expect(createResponse.json()).toMatchObject({
+			error: "Not Found",
+			message: "E2EOWNERENTITY_NOT_FOUND",
+			statusCode: 404,
+		});
 	});
 
 	it("fails when signature header is missing", async () => {

--- a/test/unit/class/api/route/runtime.class.test.ts
+++ b/test/unit/class/api/route/runtime.class.test.ts
@@ -2,9 +2,11 @@ import type { IApiRouteRuntimeHttpRequest } from "@interface/class/api/route";
 import type { ExecutionContext } from "@nestjs/common";
 
 import { ApiRouteRuntime } from "@class/api/route-runtime.class";
-import { EApiControllerRequestTarget, EApiControllerRequestTransformerType, EApiControllerResponseTarget } from "@enum/decorator/api";
+import { ApiServiceBase } from "@class/api/service-base.class";
+import { EApiControllerRelationReferenceShape, EApiControllerRequestTarget, EApiControllerRequestTransformerType, EApiControllerResponseTarget, EApiDtoType, EApiRouteType } from "@enum/decorator/api";
 import { HttpStatus, RequestMethod } from "@nestjs/common";
-import { describe, expect, it } from "vitest";
+import { ApiRouteProjectRelationResponse } from "@utility/api/route/response/project-relation.utility";
+import { describe, expect, it, vi } from "vitest";
 
 import { RuntimeRouteEmailBodyDTO, RuntimeRouteEntity, RuntimeRouteExposedEmailBodyDTO, RuntimeRouteExposedPhoneBodyDTO, RuntimeRoutePhoneBodyDTO, RuntimeRouteResponseDTO, RuntimeRouteSessionResponseDTO, RuntimeRouteVerificationResponseDTO } from "./runtime/fixture";
 
@@ -425,5 +427,402 @@ describe("ApiRouteRuntime", () => {
 				runtimeProperties: {},
 			}),
 		).rejects.toThrow("missing required discriminator field");
+	});
+
+	it("passes response relation load strategy to custom route response reload", async () => {
+		const service = new ApiServiceBase<RuntimeRouteEntity>();
+		const get = vi.spyOn(service, "get").mockResolvedValue({
+			id: "response-1",
+			source: {
+				id: "source-1",
+			} as never,
+		});
+		const controller = {
+			service,
+		};
+
+		const result = await ApiRouteRuntime.executeCustomResponseRelations(
+			controller as never,
+			{
+				relations: {
+					response: {
+						load: {
+							include: {
+								source: true,
+							} as never,
+							relationLoadStrategy: "query",
+						},
+						reference: {
+							key: "id",
+							shape: EApiControllerRelationReferenceShape.SCALAR,
+						},
+					},
+				},
+			} as never,
+			{ id: "response-1" },
+		);
+
+		expect(get).toHaveBeenCalledWith({
+			relations: {
+				source: true,
+			},
+			relationLoadStrategy: "query",
+			where: {
+				id: "response-1",
+			},
+		});
+		expect(result).toMatchObject({
+			id: "response-1",
+			source: {
+				id: "source-1",
+			},
+		});
+	});
+
+	it("skips custom route request relation loading when body is absent", async () => {
+		const ownerService = new ApiServiceBase<RuntimeRouteEntity>();
+		const get = vi.spyOn(ownerService, "get");
+		const controller = {
+			ownerService,
+		};
+
+		await ApiRouteRuntime.executeCustomRequestRelations(
+			controller as never,
+			{
+				resource: {
+					action: "custom.absentBody",
+					entity: RuntimeRouteEntity,
+				},
+				route: {
+					method: RequestMethod.POST,
+					path: "custom",
+				},
+			} as never,
+			{
+				relations: {
+					request: {
+						load: {
+							include: {
+								owner: true,
+							} as never,
+						},
+						reference: {
+							key: "id",
+							shape: EApiControllerRelationReferenceShape.SCALAR,
+						},
+					},
+				},
+			} as never,
+			undefined,
+		);
+
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it("skips custom route response reload when response include is empty", async () => {
+		const service = new ApiServiceBase<RuntimeRouteEntity>();
+		const get = vi.spyOn(service, "get");
+		const controller = {
+			service,
+		};
+		const response = { id: "response-1" };
+
+		const result = await ApiRouteRuntime.executeCustomResponseRelations(
+			controller as never,
+			{
+				relations: {
+					response: {
+						load: {
+							include: {},
+						},
+						reference: {
+							key: "id",
+							shape: EApiControllerRelationReferenceShape.SCALAR,
+						},
+					},
+				},
+			} as never,
+			response,
+		);
+
+		expect(get).not.toHaveBeenCalled();
+		expect(result).toBe(response);
+	});
+
+	it("does not project or clone custom route responses when response include is empty", async () => {
+		const request = {
+			body: {},
+			headers: {},
+			ip: "127.0.0.1",
+			params: {},
+			query: {},
+		} as IApiRouteRuntimeHttpRequest<RuntimeRouteEntity>;
+		const firstItem = new RuntimeRouteEntity();
+		firstItem.id = "response-1";
+		const response = [firstItem];
+
+		const result = await ApiRouteRuntime.executeCustom({
+			executionContext: createExecutionContext(request),
+			metadata: {
+				resource: {
+					action: "custom.emptyIncludeResponse",
+					entity: RuntimeRouteEntity,
+				},
+				response: {
+					status: HttpStatus.OK,
+					type: undefined,
+				},
+				route: {
+					method: RequestMethod.GET,
+					path: "custom",
+				},
+			},
+			operation: async () => response,
+			runtimeProperties: {
+				relations: {
+					response: {
+						load: {
+							include: {},
+						},
+						reference: {
+							key: "id",
+							shape: EApiControllerRelationReferenceShape.SCALAR,
+						},
+					},
+				},
+			},
+		});
+
+		expect(result).toBe(response);
+		expect(result[0]).toBe(firstItem);
+		expect(result[0]).toBeInstanceOf(RuntimeRouteEntity);
+	});
+
+	it("projects non-empty response includes without cloning array items", () => {
+		const firstItem = new RuntimeRouteEntity();
+		firstItem.id = "response-1";
+		firstItem.source = {
+			id: "source-1",
+		} as never;
+		const response = [firstItem];
+
+		const result = ApiRouteProjectRelationResponse(
+			{
+				load: {
+					include: {
+						source: true,
+					} as never,
+				},
+				reference: {
+					key: "id",
+					shape: EApiControllerRelationReferenceShape.SCALAR,
+				},
+			},
+			response,
+		);
+
+		expect(result).toBe(response);
+		const projectedItem: RuntimeRouteEntity = result[0] as RuntimeRouteEntity;
+
+		expect(projectedItem).toBe(firstItem);
+		expect(projectedItem).toBeInstanceOf(RuntimeRouteEntity);
+		expect(projectedItem.source).toBe("source-1");
+	});
+
+	it("projects non-empty response includes without cloning get-list items", () => {
+		const firstItem = new RuntimeRouteEntity();
+		firstItem.id = "response-1";
+		firstItem.source = {
+			id: "source-1",
+		} as never;
+		const response = {
+			items: [firstItem],
+		};
+
+		const result = ApiRouteProjectRelationResponse(
+			{
+				load: {
+					include: {
+						source: true,
+					} as never,
+				},
+				reference: {
+					key: "id",
+					shape: EApiControllerRelationReferenceShape.OBJECT,
+				},
+			},
+			response,
+		);
+
+		expect(result).toBe(response);
+		const projectedItem: RuntimeRouteEntity = result.items[0] as RuntimeRouteEntity;
+
+		expect(projectedItem).toBe(firstItem);
+		expect(projectedItem).toBeInstanceOf(RuntimeRouteEntity);
+		expect(projectedItem.source).toEqual({ id: "source-1" });
+	});
+
+	it("throws configuration error when response relation reference is missing", () => {
+		expect(() =>
+			ApiRouteProjectRelationResponse(
+				{
+					load: {
+						include: {
+							source: true,
+						} as never,
+					},
+				} as never,
+				{ id: "response-1" },
+			),
+		).toThrow("Response relation reference config is required when relation loading is configured");
+	});
+
+	it("passes response relation load strategy to generated GET relation loading", async () => {
+		const service = new ApiServiceBase<RuntimeRouteEntity>();
+		const get = vi.spyOn(service, "get").mockResolvedValue({
+			id: "response-1",
+		});
+		const controller = {
+			service,
+		};
+
+		await ApiRouteRuntime.executeGenerated({
+			controller: controller as never,
+			entityMetadata: {
+				columns: [
+					{
+						isPrimary: true,
+						name: "id",
+						type: "varchar",
+					},
+				],
+				primaryKey: {
+					isPrimary: true,
+					name: "id",
+					type: "varchar",
+				},
+				tableName: "runtime_route_entities",
+			},
+			method: EApiRouteType.GET,
+			methodName: "get",
+			properties: {
+				entity: RuntimeRouteEntity,
+				routes: {
+					[EApiRouteType.GET]: {
+						dto: {
+							[EApiDtoType.RESPONSE]: RuntimeRouteResponseDTO,
+						},
+						relations: {
+							response: {
+								load: {
+									include: {
+										source: true,
+									} as never,
+									relationLoadStrategy: "query",
+								},
+								reference: {
+									key: "id",
+									shape: EApiControllerRelationReferenceShape.SCALAR,
+								},
+							},
+						},
+						response: {
+							serialization: {
+								isEnabled: false,
+							},
+						},
+					},
+				},
+			},
+			targets: {
+				headers: {},
+				ip: "127.0.0.1",
+				parameters: {
+					id: "response-1",
+				},
+			},
+		});
+
+		expect(get).toHaveBeenCalledWith({
+			relationLoadStrategy: "query",
+			relations: {
+				source: true,
+			},
+			where: {
+				id: "response-1",
+			},
+		});
+	});
+
+	it("passes response relation load strategy to generated GET_LIST relation loading", async () => {
+		const service = new ApiServiceBase<RuntimeRouteEntity>();
+		const getList = vi.spyOn(service, "getList").mockResolvedValue({
+			count: 0,
+			currentPage: 1,
+			items: [],
+			totalCount: 0,
+			totalPages: 0,
+		});
+		const controller = {
+			service,
+		};
+
+		await ApiRouteRuntime.executeGenerated({
+			controller: controller as never,
+			entityMetadata: {
+				columns: [],
+				primaryKey: undefined,
+				tableName: "runtime_route_entities",
+			},
+			method: EApiRouteType.GET_LIST,
+			methodName: "getList",
+			properties: {
+				entity: RuntimeRouteEntity,
+				routes: {
+					[EApiRouteType.GET_LIST]: {
+						dto: {
+							[EApiDtoType.RESPONSE]: RuntimeRouteResponseDTO,
+						},
+						relations: {
+							response: {
+								load: {
+									include: {
+										source: true,
+									} as never,
+									relationLoadStrategy: "query",
+								},
+								reference: {
+									key: "id",
+									shape: EApiControllerRelationReferenceShape.SCALAR,
+								},
+							},
+						},
+						response: {
+							serialization: {
+								isEnabled: false,
+							},
+						},
+					},
+				},
+			},
+			targets: {
+				headers: {},
+				ip: "127.0.0.1",
+				query: {
+					limit: 10,
+					page: 1,
+				} as never,
+			},
+		});
+
+		expect(getList).toHaveBeenCalledWith({
+			relationLoadStrategy: "query",
+			relations: {
+				source: true,
+			},
+			skip: 0,
+			take: 10,
+			where: {},
+		});
 	});
 });

--- a/test/unit/utility/api/controller/handle-request-relations.utility.test.ts
+++ b/test/unit/utility/api/controller/handle-request-relations.utility.test.ts
@@ -1,12 +1,13 @@
 import "reflect-metadata";
 
 import type { IApiControllerProperties } from "@interface/decorator/api";
+import type { FindOptionsRelations } from "typeorm";
 
 import { ApiServiceBase } from "@class/api";
-import { EApiControllerLoadRelationsStrategy, EApiControllerRelationReferenceShape } from "@enum/decorator/api";
+import { EApiControllerRelationReferenceShape } from "@enum/decorator/api";
 import { ApiControllerHandleRequestRelations } from "@utility/api/controller/handle-request-relations.utility";
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 @Entity("relation_owners")
 class RelationOwner {
@@ -34,23 +35,17 @@ class RelationOwnerService extends ApiServiceBase<RelationOwner> {
 
 const createRelationConfig = (
 	overrides: {
+		include?: FindOptionsRelations<RelationEntity>;
 		referenceKey?: string;
 		referenceShape?: EApiControllerRelationReferenceShape;
-		relationStrategy?: EApiControllerLoadRelationsStrategy;
-		relations?: Array<"owner">;
-		serviceStrategy?: EApiControllerLoadRelationsStrategy;
+		relationLoadStrategy?: "join" | "query";
 		services?: Partial<Record<"owner", string>>;
-		shouldForceAllServicesToBeSpecified?: boolean;
-		shouldLoad?: boolean;
 	} = {},
 ) => ({
 	load: {
-		relationStrategy: overrides.relationStrategy ?? EApiControllerLoadRelationsStrategy.AUTO,
-		relations: overrides.relations,
-		serviceStrategy: overrides.serviceStrategy ?? EApiControllerLoadRelationsStrategy.AUTO,
+		include: "include" in overrides ? overrides.include : { owner: true },
+		relationLoadStrategy: overrides.relationLoadStrategy,
 		services: overrides.services,
-		shouldForceAllServicesToBeSpecified: overrides.shouldForceAllServicesToBeSpecified,
-		shouldLoad: overrides.shouldLoad ?? true,
 	},
 	reference: {
 		key: overrides.referenceKey,
@@ -59,34 +54,43 @@ const createRelationConfig = (
 });
 
 describe("ApiControllerHandleRequestRelations", () => {
-	it("loads relations using auto strategy", async () => {
+	it("loads included relations using inferred service names", async () => {
+		const ownerService = new RelationOwnerService();
+		const getSpy = vi.spyOn(ownerService, "get");
 		const controller = {
-			ownerService: new RelationOwnerService(),
+			ownerService,
 		};
 		const properties: IApiControllerProperties<RelationEntity> = {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig();
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
 		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
 
+		expect(getSpy).toHaveBeenCalledWith({ where: { id: "owner-1" } });
 		expect(parameters.owner).toMatchObject({ id: "owner-1" });
 	});
 
-	it("throws when service is missing in forced mode", async () => {
+	it("does nothing when load is missing", async () => {
 		const properties: IApiControllerProperties<RelationEntity> = {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ shouldForceAllServicesToBeSpecified: true });
+		const relationConfig = {
+			reference: {
+				shape: EApiControllerRelationReferenceShape.SCALAR,
+			},
+		};
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
-		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service ownerService not found in controller");
+		await ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters);
+
+		expect(parameters.owner).toBe("owner-1");
 	});
 
-	it("throws when manual service name is not provided", async () => {
+	it("does nothing when include is empty", async () => {
 		const controller = {
 			ownerService: new RelationOwnerService(),
 		};
@@ -94,10 +98,88 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ serviceStrategy: EApiControllerLoadRelationsStrategy.MANUAL, services: {}, shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ include: {} });
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
-		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service name not specified for property owner in manual mode");
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(parameters.owner).toBe("owner-1");
+	});
+
+	it("throws when include is missing from a configured load block", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = {
+			load: {},
+			reference: {
+				shape: EApiControllerRelationReferenceShape.SCALAR,
+			},
+		};
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Request relation load include must be an object");
+	});
+
+	it("throws when include is null", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ include: null as never });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Request relation load include must be an object");
+	});
+
+	it("throws when include is an array", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ include: [] as never });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Request relation load include must be an object");
+	});
+
+	it("throws when reference shape is missing", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = {
+			load: {
+				include: { owner: true },
+			},
+			reference: {},
+		};
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Request relation reference shape must be OBJECT or SCALAR");
+	});
+
+	it("throws when reference key is empty", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ referenceKey: "" });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Request relation reference key must not be empty");
+	});
+
+	it("throws when service is missing for an included relation", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig();
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service ownerService not found in controller");
 	});
 
 	it("throws when service is not an ApiServiceBase", async () => {
@@ -108,13 +190,13 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig();
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
-		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service ownerService is not an instance of BaseApiService");
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service ownerService is not an instance of ApiServiceBase");
 	});
 
-	it("skips relations not listed in manual load strategy", async () => {
+	it("skips relation fields not listed in include", async () => {
 		const controller = {
 			ownerService: new RelationOwnerService(),
 		};
@@ -122,7 +204,7 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ relationStrategy: EApiControllerLoadRelationsStrategy.MANUAL, relations: [], shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ include: {} });
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
 		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
@@ -130,7 +212,7 @@ describe("ApiControllerHandleRequestRelations", () => {
 		expect(parameters.owner).toBe("owner-1");
 	});
 
-	it("loads relations using manual service mapping", async () => {
+	it("loads relations using service override mapping", async () => {
 		class CustomOwnerService extends ApiServiceBase<RelationOwner> {
 			public override async get(): Promise<RelationOwner> {
 				return { id: "owner-2", name: "Custom" };
@@ -144,7 +226,7 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ serviceStrategy: EApiControllerLoadRelationsStrategy.MANUAL, services: { owner: "customOwnerService" }, shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ services: { owner: "customOwnerService" } });
 		const parameters: Partial<RelationEntity> = { owner: "owner-2" as never };
 
 		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
@@ -168,7 +250,7 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ referenceKey: "name", shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ referenceKey: "name" });
 		const parameters: Partial<RelationEntity> = { owner: "owner-code" as never };
 
 		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
@@ -184,7 +266,7 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ referenceShape: EApiControllerRelationReferenceShape.OBJECT, shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ referenceShape: EApiControllerRelationReferenceShape.OBJECT });
 		const parameters: Partial<RelationEntity> = { owner: { id: "owner-1" } as never };
 
 		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
@@ -192,7 +274,151 @@ describe("ApiControllerHandleRequestRelations", () => {
 		expect(parameters.owner).toMatchObject({ id: "owner-1" });
 	});
 
-	it("throws when relation id is invalid", async () => {
+	it("loads object references by a custom reference key", async () => {
+		class CodeOwnerService extends ApiServiceBase<RelationOwner> {
+			public override async get(properties: unknown): Promise<RelationOwner> {
+				expect(properties).toEqual({ where: { name: "owner-code" } });
+
+				return { id: "owner-by-code", name: "owner-code" };
+			}
+		}
+
+		const controller = {
+			ownerService: new CodeOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ referenceKey: "name", referenceShape: EApiControllerRelationReferenceShape.OBJECT });
+		const parameters: Partial<RelationEntity> = { owner: { name: "owner-code" } as never };
+
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(parameters.owner).toMatchObject({ id: "owner-by-code", name: "owner-code" });
+	});
+
+	it("throws when scalar reference shape receives an object", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig();
+		const parameters: Partial<RelationEntity> = { owner: { id: "owner-1" } as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toMatchObject({
+			response: {
+				details: {
+					expectedShape: EApiControllerRelationReferenceShape.SCALAR,
+					propertyName: "owner",
+					referenceKey: "id",
+				},
+				message: "RELATIONENTITY_INVALID_REFERENCE",
+				statusCode: 400,
+			},
+		});
+	});
+
+	it("throws when object reference shape receives a scalar", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ referenceShape: EApiControllerRelationReferenceShape.OBJECT });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toMatchObject({
+			response: {
+				details: {
+					expectedShape: EApiControllerRelationReferenceShape.OBJECT,
+					propertyName: "owner",
+					referenceKey: "id",
+				},
+				message: "RELATIONENTITY_INVALID_REFERENCE",
+				statusCode: 400,
+			},
+		});
+	});
+
+	it("throws when object reference shape misses the configured key", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ referenceKey: "name", referenceShape: EApiControllerRelationReferenceShape.OBJECT });
+		const parameters: Partial<RelationEntity> = { owner: { id: "owner-1" } as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toMatchObject({
+			response: {
+				details: {
+					expectedShape: EApiControllerRelationReferenceShape.OBJECT,
+					propertyName: "owner",
+					referenceKey: "name",
+				},
+				message: "RELATIONENTITY_INVALID_REFERENCE",
+				statusCode: 400,
+			},
+		});
+	});
+
+	it("throws when object reference key value is null", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ referenceShape: EApiControllerRelationReferenceShape.OBJECT });
+		const parameters: Partial<RelationEntity> = { owner: { id: null } as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toMatchObject({
+			response: {
+				details: {
+					expectedShape: EApiControllerRelationReferenceShape.OBJECT,
+					propertyName: "owner",
+					referenceKey: "id",
+				},
+				message: "RELATIONENTITY_INVALID_REFERENCE",
+				statusCode: 400,
+			},
+		});
+	});
+
+	it("throws when object reference key value is undefined", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ referenceShape: EApiControllerRelationReferenceShape.OBJECT });
+		const parameters: Partial<RelationEntity> = { owner: { id: undefined } as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toMatchObject({
+			response: {
+				details: {
+					expectedShape: EApiControllerRelationReferenceShape.OBJECT,
+					propertyName: "owner",
+					referenceKey: "id",
+				},
+				message: "RELATIONENTITY_INVALID_REFERENCE",
+				statusCode: 400,
+			},
+		});
+	});
+
+	it("throws configuration error when relation service returns no entity", async () => {
 		class MissingOwnerService extends ApiServiceBase<RelationOwner> {
 			public override async get(): Promise<RelationOwner> {
 				return undefined as never;
@@ -206,13 +432,13 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig();
 		const parameters: Partial<RelationEntity> = { owner: "missing" as never };
 
-		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Invalid owner ID");
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service ownerService returned an empty relation entity");
 	});
 
-	it("throws when manual service name is empty", async () => {
+	it("throws when service override name is empty", async () => {
 		const controller = {
 			ownerService: new RelationOwnerService(),
 		};
@@ -220,22 +446,172 @@ describe("ApiControllerHandleRequestRelations", () => {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ serviceStrategy: EApiControllerLoadRelationsStrategy.MANUAL, services: { owner: "" }, shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ services: { owner: "" } });
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
 		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service name not specified for property owner");
 	});
 
-	it("skips missing services when not forced", async () => {
+	it("throws when service override points to a missing controller service", async () => {
 		const properties: IApiControllerProperties<RelationEntity> = {
 			entity: RelationEntity,
 			routes: {},
 		};
-		const relationConfig = createRelationConfig({ shouldForceAllServicesToBeSpecified: false });
+		const relationConfig = createRelationConfig({ services: { owner: "missingOwnerService" } });
 		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
 
-		await ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters);
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Service missingOwnerService not found in controller");
+	});
 
+	it("throws when include contains an unknown relation key", async () => {
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ include: { missing: true } as never });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations({} as never, properties, relationConfig as never, parameters)).rejects.toThrow("Relation missing is not a direct relation on the entity");
+	});
+
+	it("skips included relations that are absent from the payload", async () => {
+		const ownerService = new RelationOwnerService();
+		const getSpy = vi.spyOn(ownerService, "get");
+		const controller = {
+			ownerService,
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig();
+		const parameters: Partial<RelationEntity> = {};
+
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(getSpy).not.toHaveBeenCalled();
+		expect(parameters.owner).toBeUndefined();
+	});
+
+	it("skips included relations with undefined payload values", async () => {
+		const ownerService = new RelationOwnerService();
+		const getSpy = vi.spyOn(ownerService, "get");
+		const controller = {
+			ownerService,
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig();
+		const parameters: Partial<RelationEntity> = { owner: undefined };
+
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(getSpy).not.toHaveBeenCalled();
+		expect(parameters.owner).toBeUndefined();
+	});
+
+	it("leaves null relation values unchanged", async () => {
+		const ownerService = new RelationOwnerService();
+		const getSpy = vi.spyOn(ownerService, "get");
+		const controller = {
+			ownerService,
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig();
+		const parameters: Partial<RelationEntity> = { owner: null as never };
+
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(getSpy).not.toHaveBeenCalled();
+		expect(parameters.owner).toBeNull();
+	});
+
+	it("skips include values set to false", async () => {
+		const ownerService = new RelationOwnerService();
+		const getSpy = vi.spyOn(ownerService, "get");
+		const controller = {
+			ownerService,
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ include: { owner: false } as never });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(getSpy).not.toHaveBeenCalled();
 		expect(parameters.owner).toBe("owner-1");
+	});
+
+	it("throws when include value is malformed", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ include: { owner: "profile" } as never });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Invalid include value for relation owner");
+	});
+
+	it("throws when include object value is null", async () => {
+		const controller = {
+			ownerService: new RelationOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({ include: { owner: null } as never });
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await expect(ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters)).rejects.toThrow("Invalid include value for relation owner");
+	});
+
+	it("passes nested include and relation load strategy to relation service", async () => {
+		class NestedOwnerService extends ApiServiceBase<RelationOwner> {
+			public override async get(properties: unknown): Promise<RelationOwner> {
+				expect(properties).toEqual({
+					relationLoadStrategy: "query",
+					relations: {
+						profile: true,
+					},
+					where: { id: "owner-1" },
+				});
+
+				return { id: "owner-1", name: "Owner" };
+			}
+		}
+
+		const controller = {
+			ownerService: new NestedOwnerService(),
+		};
+		const properties: IApiControllerProperties<RelationEntity> = {
+			entity: RelationEntity,
+			routes: {},
+		};
+		const relationConfig = createRelationConfig({
+			include: {
+				owner: {
+					profile: true,
+				} as never,
+			},
+			relationLoadStrategy: "query",
+		});
+		const parameters: Partial<RelationEntity> = { owner: "owner-1" as never };
+
+		await ApiControllerHandleRequestRelations(controller as never, properties, relationConfig as never, parameters);
+
+		expect(parameters.owner).toMatchObject({ id: "owner-1" });
 	});
 });


### PR DESCRIPTION
## Summary
- Replace the legacy request relation loading strategy API with TypeORM-shaped `request.load.include` maps.
- Pass `relationLoadStrategy` consistently across request and response relation loading paths.
- Expand docs, AI guidance, unit/e2e coverage, and CI lint validation for the new relation contract.

## Test plan
- `npm run lint:types`
- `npm run lint`
- `npm run test:unit -- test/unit/utility/api/controller/handle-request-relations.utility.test.ts test/unit/class/api/route/runtime.class.test.ts`
- `npm run test:e2e -- test/e2e/http/crud.e2e.test.ts`
- `npm run test:e2e`
- `git diff --check`