### PR TITLE
feat(api): add transaction-aware function steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,24 @@ async bulkPromote(ids: Array<string>): Promise<Array<UserEntity>> {
 }
 ```
 
+Use `@ApiFunctionStep` for internal helper methods that need ApiFunction transaction semantics and context but should not become standalone custom actions:
+
+```typescript
+import { ApiFunctionStep, EApiFunctionTransactionMode } from "@elsikora/nestjs-crud-automator";
+
+@ApiFunctionStep<UserEntity>({
+	entity: UserEntity,
+	transaction: { mode: EApiFunctionTransactionMode.MANDATORY },
+})
+private async recordPromotionAudit(user: UserEntity): Promise<void> {
+	const context = this.getApiFunctionStepContext<UserEntity>();
+
+	await context.repository.save(user);
+}
+```
+
+Steps do not dispatch function subscribers, create route metadata, or define Swagger/authorization action identities. Step context intentionally exposes only `eventManager`, `repository`, and `getRepository`; use `@ApiFunctionCustom` plus `getApiFunctionContext()` when you need `operations` or lifecycle hooks.
+
 ```typescript
 // app.module.ts
 import type { IApiAuthorizationPrincipal, IApiHookPermissionSource, IApiPolicyAttachmentSource, IApiPolicyDocumentSource, IApiResolvedPolicyAttachments } from "@elsikora/nestjs-crud-automator";

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ async bulkPromote(ids: Array<string>): Promise<Array<UserEntity>> {
 }
 ```
 
-Use `@ApiFunctionStep` for internal helper methods that need ApiFunction transaction semantics and context but should not become standalone custom actions:
+Use `@ApiFunctionStep` for internal helper methods that need ApiFunction transaction semantics and context but should not become standalone custom actions. Steps can also be called directly when the selected transaction mode permits:
 
 ```typescript
 import { ApiFunctionStep, EApiFunctionTransactionMode } from "@elsikora/nestjs-crud-automator";

--- a/ai/crud-automator/SKILL.md
+++ b/ai/crud-automator/SKILL.md
@@ -43,9 +43,12 @@ Use local source as the contract:
 - Service/function `get`, `getList`, and `getMany` receive TypeORM options.
 - Generated service/context `delete` is `Promise<void>`; direct decorator internals have a known return-shape inconsistency, so document and test the intended surface before changing it.
 - `@ApiFunctionCustom({ action, entity, transaction })` is for custom service commands that need function lifecycle, subscribers, and transaction context.
+- `@ApiFunctionStep({ entity, transaction })` is for internal service helper methods that need transaction context but are not standalone actions.
+- Function steps do not create subscriber hooks, route metadata, Swagger metadata, or authorization action identities; do not model them as custom actions.
 - `@ApiService({ entity, functions })` can configure transaction modes for generated CRUD functions keyed by `EApiFunctionType.CREATE`, `UPDATE`, `DELETE`, `GET`, `GET_LIST`, and `GET_MANY`; omitted entries default to `SUPPORTS`, and `CUSTOM` belongs to `@ApiFunctionCustom`.
 - Transaction modes are `SUPPORTS`, `REQUIRED`, `MANDATORY`, and `NONE`.
 - Inside decorated service execution, use `this.getApiFunctionContext()` for `operations`, `repository`, `eventManager`, and `getRepository`.
+- Inside `@ApiFunctionStep`, use `this.getApiFunctionStepContext()` for `repository`, `eventManager`, and `getRepository`; it intentionally omits `operations`.
 - `ApiFunctionTransactionScope.runWithDataSource()` and `runWithEntityManager()` provide external transaction scope; CRUD `operations` reject without a decorated service context.
 
 ## Route Runtime Model

--- a/ai/crud-automator/SKILL.md
+++ b/ai/crud-automator/SKILL.md
@@ -43,7 +43,7 @@ Use local source as the contract:
 - Service/function `get`, `getList`, and `getMany` receive TypeORM options.
 - Generated service/context `delete` is `Promise<void>`; direct decorator internals have a known return-shape inconsistency, so document and test the intended surface before changing it.
 - `@ApiFunctionCustom({ action, entity, transaction })` is for custom service commands that need function lifecycle, subscribers, and transaction context.
-- `@ApiFunctionStep({ entity, transaction })` is for internal service helper methods that need transaction context but are not standalone actions.
+- `@ApiFunctionStep({ entity, transaction })` is for internal service helper methods that need transaction context but are not standalone actions; direct calls are valid when the selected transaction mode permits.
 - Function steps do not create subscriber hooks, route metadata, Swagger metadata, or authorization action identities; do not model them as custom actions.
 - `@ApiService({ entity, functions })` can configure transaction modes for generated CRUD functions keyed by `EApiFunctionType.CREATE`, `UPDATE`, `DELETE`, `GET`, `GET_LIST`, and `GET_MANY`; omitted entries default to `SUPPORTS`, and `CUSTOM` belongs to `@ApiFunctionCustom`.
 - Transaction modes are `SUPPORTS`, `REQUIRED`, `MANDATORY`, and `NONE`.

--- a/ai/crud-automator/pitfalls.md
+++ b/ai/crud-automator/pitfalls.md
@@ -35,7 +35,7 @@ Route before hooks can use `context.result.body`.
 
 ## Function Step Overreach
 
-Use `@ApiFunctionStep` only for internal transaction-aware service helpers. Do not use it as a replacement for `@ApiFunctionCustom` when the operation needs an action name, function subscribers, route metadata, Swagger metadata, or authorization action identity.
+Use `@ApiFunctionStep` only for internal transaction-aware service helpers, including direct helper calls when the selected transaction mode permits. Do not use it as a replacement for `@ApiFunctionCustom` when the operation needs an action name, function subscribers, route metadata, Swagger metadata, or authorization action identity.
 
 Inside a step, prefer `this.getApiFunctionStepContext()` for `eventManager`, `repository`, and `getRepository()`. It intentionally does not expose `operations`; standalone domain actions should remain `@ApiFunctionCustom`.
 

--- a/ai/crud-automator/pitfalls.md
+++ b/ai/crud-automator/pitfalls.md
@@ -33,6 +33,12 @@ context.result.body.slug = "hello";
 
 Route before hooks can use `context.result.body`.
 
+## Function Step Overreach
+
+Use `@ApiFunctionStep` only for internal transaction-aware service helpers. Do not use it as a replacement for `@ApiFunctionCustom` when the operation needs an action name, function subscribers, route metadata, Swagger metadata, or authorization action identity.
+
+Inside a step, prefer `this.getApiFunctionStepContext()` for `eventManager`, `repository`, and `getRepository()`. It intentionally does not expose `operations`; standalone domain actions should remain `@ApiFunctionCustom`.
+
 ## Auto DTO Overreach
 
 `autoDto` is for validators only. It does not control exposure, guard visibility, filters, response serialization, or requiredness. Put those in `ApiPropertyDescribe({ properties })` or use manual `dto`.

--- a/ai/crud-automator/reference.md
+++ b/ai/crud-automator/reference.md
@@ -6,6 +6,7 @@
 | ----------------------------------------------- | ------------------------------------------------------- |
 | Standard CRUD                                   | `@ApiService()` + `ApiServiceBase` + `@ApiController()` |
 | Custom service command                          | `@ApiFunctionCustom()`                                  |
+| Internal transaction-aware service step         | `@ApiFunctionStep()`                                    |
 | Custom controller command with runtime pipeline | `@ApiRouteCustom()`                                     |
 | Low-level custom method metadata                | `@ApiMethod({ metadata })`                              |
 | Generated DTO field controls                    | `ApiPropertyDescribe({ properties })`                   |
@@ -97,6 +98,8 @@ getMany(properties: FindManyOptions<E>): Promise<Array<E>>;
 Controller GET_LIST query parameters (`limit`, `page`, `orderBy`, `orderDirection`, bracketed filters) are converted to TypeORM `take`, `skip`, `order`, and `where` before the service is called.
 
 `@ApiFunctionDelete` internally removes an entity snapshot, but generated service/controller delete APIs intentionally expose `Promise<void>`. Do not design public delete flows around receiving the removed entity unless the source contract is changed first.
+
+Use `@ApiFunctionStep({ entity, transaction })` for private/protected/public helper methods inside service use-cases when they need the current transaction context. In a step, call `this.getApiFunctionStepContext()` for `eventManager`, `repository`, and `getRepository()`. Steps are not custom actions and do not dispatch function subscribers, route metadata, Swagger metadata, or authorization action identities.
 
 ## Custom Route Boundary
 

--- a/ai/crud-automator/reference.md
+++ b/ai/crud-automator/reference.md
@@ -99,7 +99,7 @@ Controller GET_LIST query parameters (`limit`, `page`, `orderBy`, `orderDirectio
 
 `@ApiFunctionDelete` internally removes an entity snapshot, but generated service/controller delete APIs intentionally expose `Promise<void>`. Do not design public delete flows around receiving the removed entity unless the source contract is changed first.
 
-Use `@ApiFunctionStep({ entity, transaction })` for private/protected/public helper methods inside service use-cases when they need the current transaction context. In a step, call `this.getApiFunctionStepContext()` for `eventManager`, `repository`, and `getRepository()`. Steps are not custom actions and do not dispatch function subscribers, route metadata, Swagger metadata, or authorization action identities.
+Use `@ApiFunctionStep({ entity, transaction })` for private/protected/public helper methods inside service use-cases when they need the current transaction context. Direct calls are valid when the selected transaction mode permits. In a step, call `this.getApiFunctionStepContext()` for `eventManager`, `repository`, and `getRepository()`. Steps are not custom actions and do not dispatch function subscribers, route metadata, Swagger metadata, or authorization action identities.
 
 ## Custom Route Boundary
 

--- a/docs/api-reference/classes/page.mdx
+++ b/docs/api-reference/classes/page.mdx
@@ -82,6 +82,17 @@ const context = this.getApiFunctionContext<PostEntity>();
 await context.operations.update({ id }, { status: "published" });
 ```
 
+#### `protected getApiFunctionStepContext(): IApiFunctionStepContext<T>`
+
+Returns the active transaction-aware step context inside an `@ApiFunctionStep` method. Use it for internal helpers that need `eventManager`, the entity `repository`, or `getRepository()` without exposing `EntityManager` in the method signature.
+
+```typescript
+const context = this.getApiFunctionStepContext<PostEntity>();
+await context.repository.save(post);
+```
+
+`getApiFunctionStepContext()` intentionally omits `operations`. Use `@ApiFunctionCustom` and `getApiFunctionContext()` for standalone custom service actions that need function lifecycle helpers and subscribers.
+
 **Related:**
 
 - [Core Concepts - Services](/docs/nestjs-crud-automator/core-concepts/services)
@@ -231,7 +242,7 @@ Public helper for running code inside an external TypeORM transaction while maki
 - `runWithDataSource(dataSource, callback)` opens a new TypeORM transaction.
 - `runWithEntityManager(entityManager, callback)` reuses an existing `EntityManager`.
 
-Only service-bound `@ApiFunction` execution has real CRUD `operations`; transaction scopes created without a decorated service expose `getRepository` and transaction metadata but reject CRUD operations because there is no owning service context.
+Only service-bound decorated function execution, including generated `@ApiFunction` flows and `@ApiFunctionCustom`, has real CRUD `operations`; transaction scopes created without a decorated service expose `getRepository` and transaction metadata but reject CRUD operations because there is no owning service context.
 
 ## Subscriber Management Classes
 

--- a/docs/api-reference/decorators/api-function/_meta.js
+++ b/docs/api-reference/decorators/api-function/_meta.js
@@ -6,5 +6,6 @@ export default {
 	"api-function-get": "@ApiFunctionGet",
 	"api-function-get-list": "@ApiFunctionGetList",
 	"api-function-get-many": "@ApiFunctionGetMany",
+	"api-function-step": "@ApiFunctionStep",
 	"api-function-update": "@ApiFunctionUpdate",
 };

--- a/docs/api-reference/decorators/api-function/api-function-custom/page.mdx
+++ b/docs/api-reference/decorators/api-function/api-function-custom/page.mdx
@@ -12,11 +12,11 @@
 
 ## Options
 
-| Option             | Type                          | Description                                                                 |
-| ------------------ | ----------------------------- | --------------------------------------------------------------------------- |
-| `entity`           | `new () => E`                 | Entity constructor used for subscribers, repositories, and context helpers. |
-| `action`           | `string`                      | Custom action name used by function subscriber filters.                     |
-| `transaction.mode` | `EApiFunctionTransactionMode` | Optional transaction mode. Defaults to `SUPPORTS`.                          |
+| Option             | Type                                       | Description                                                                 |
+| ------------------ | ------------------------------------------ | --------------------------------------------------------------------------- |
+| `entity`           | `new (...arguments_: Array<unknown>) => E` | Entity constructor used for subscribers, repositories, and context helpers. |
+| `action`           | `string`                                   | Custom action name used by function subscriber filters.                     |
+| `transaction.mode` | `EApiFunctionTransactionMode`              | Optional transaction mode. Defaults to `SUPPORTS`.                          |
 
 ## Lifecycle
 

--- a/docs/api-reference/decorators/api-function/api-function-custom/page.mdx
+++ b/docs/api-reference/decorators/api-function/api-function-custom/page.mdx
@@ -62,7 +62,13 @@ async checkout(orderId: string): Promise<OrderEntity> {
 | `getRepository` | `<T extends IApiBaseEntity>(entity: new () => T) => Repository<T>`                                                                             |
 | `update`        | `(criteria: TApiFunctionUpdateCriteria<E> \| Array<TApiFunctionUpdateCriteria<E>>, properties: TApiFunctionUpdateProperties<E>) => Promise<E>` |
 
-`this.getApiFunctionContext()` is only available while a decorated function is executing. Calling it outside `@ApiFunction` or `@ApiFunctionCustom` throws.
+`this.getApiFunctionContext()` is only available while a decorated function is executing. Calling it outside `@ApiFunction` or `@ApiFunctionCustom` throws. It is also unavailable inside `@ApiFunctionStep`; use `this.getApiFunctionStepContext()` there.
+
+## Custom Function vs Function Step
+
+Use `@ApiFunctionCustom` for standalone domain actions that need an `action` name, function subscribers, lifecycle hooks, and `context.operations`.
+
+Use `@ApiFunctionStep` for internal helper methods inside custom commands, generated or decorated service flows, or direct helper calls when the selected transaction mode permits and the helper only needs transaction context. Steps do not dispatch subscribers and do not create action, route, Swagger, or authorization metadata.
 
 ## Subscriber example
 

--- a/docs/api-reference/decorators/api-function/api-function-step/page.mdx
+++ b/docs/api-reference/decorators/api-function/api-function-step/page.mdx
@@ -21,12 +21,12 @@ It is not a standalone function action. It does not dispatch function subscriber
 
 ## Transaction modes
 
-- `SUPPORTS` joins an active function transaction when one exists and otherwise runs without opening one.
+- `SUPPORTS` joins an active transaction context when one exists and otherwise runs without opening one.
 - `REQUIRED` joins an active transaction or opens a new TypeORM transaction from the service repository.
 - `MANDATORY` requires an active transaction and fails before the step body when none exists.
 - `NONE` requires no active transaction and fails before the step body when one exists.
 
-Use `MANDATORY` when a step must only run inside an existing function transaction. Use `REQUIRED` when the step may also be called directly and should create its own transaction.
+Use `MANDATORY` when a step must only run inside an existing transaction context. Use `REQUIRED` when the step may also be called directly and should create its own transaction.
 
 ## Context
 

--- a/docs/api-reference/decorators/api-function/api-function-step/page.mdx
+++ b/docs/api-reference/decorators/api-function/api-function-step/page.mdx
@@ -14,10 +14,10 @@ It is not a standalone function action. It does not dispatch function subscriber
 
 ## Options
 
-| Option             | Type                                       | Description                                        |
-| ------------------ | ------------------------------------------ | -------------------------------------------------- |
-| `entity`           | `new (...arguments_: Array<unknown>) => E` | Entity constructor used for repository resolution. |
-| `transaction.mode` | `EApiFunctionTransactionMode`              | Optional transaction mode. Defaults to `SUPPORTS`. |
+| Option             | Type                                       | Description                                                                                                 |
+| ------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `entity`           | `new (...arguments_: Array<unknown>) => E` | Entity constructor used for repository resolution.                                                          |
+| `transaction.mode` | `EApiFunctionTransactionMode`              | `transaction` is optional. When provided, `mode` is required. Omitted `transaction` defaults to `SUPPORTS`. |
 
 ## Transaction modes
 

--- a/docs/api-reference/decorators/api-function/api-function-step/page.mdx
+++ b/docs/api-reference/decorators/api-function/api-function-step/page.mdx
@@ -1,0 +1,61 @@
+# `@ApiFunctionStep`
+
+`@ApiFunctionStep` wraps an internal service helper with ApiFunction transaction semantics. Use it to decompose a larger `@ApiFunctionCustom` or generated function flow without exposing `EntityManager` in method signatures.
+
+It is not a standalone function action. It does not dispatch function subscribers, register route metadata, generate Swagger metadata, or create an authorization action identity.
+
+## Signature
+
+```typescript
+@ApiFunctionStep<E extends IApiBaseEntity>(
+	properties: IApiFunctionStepProperties<E>
+): (target, propertyKey, descriptor) => PropertyDescriptor
+```
+
+## Options
+
+| Option             | Type                                       | Description                                        |
+| ------------------ | ------------------------------------------ | -------------------------------------------------- |
+| `entity`           | `new (...arguments_: Array<unknown>) => E` | Entity constructor used for repository resolution. |
+| `transaction.mode` | `EApiFunctionTransactionMode`              | Optional transaction mode. Defaults to `SUPPORTS`. |
+
+## Transaction modes
+
+- `SUPPORTS` joins an active function transaction when one exists and otherwise runs without opening one.
+- `REQUIRED` joins an active transaction or opens a new TypeORM transaction from the service repository.
+- `MANDATORY` requires an active transaction and fails before the step body when none exists.
+- `NONE` requires no active transaction and fails before the step body when one exists.
+
+Use `MANDATORY` when a step must only run inside an existing function transaction. Use `REQUIRED` when the step may also be called directly and should create its own transaction.
+
+## Context
+
+Inside a step, call `this.getApiFunctionStepContext()` from an `ApiServiceBase` subclass:
+
+```typescript
+@ApiFunctionStep<WithdrawalEntity>({
+	entity: WithdrawalEntity,
+	transaction: { mode: EApiFunctionTransactionMode.MANDATORY },
+})
+private async releaseReservedWithdrawalAmount(properties: IReleaseReservedWithdrawalAmountProperties): Promise<WithdrawalEntity> {
+	const context = this.getApiFunctionStepContext<WithdrawalEntity>();
+
+	return await context.repository.save(properties.withdrawal);
+}
+```
+
+The step context intentionally exposes only:
+
+| Property          | Description                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| `eventManager`    | Active TypeORM transaction manager, when one is present.                  |
+| `repository`      | Entity repository resolved from the active manager or service repository. |
+| `getRepository()` | Helper for resolving repositories with the active manager when available. |
+
+It does not expose `operations`. Use `@ApiFunctionCustom` and `this.getApiFunctionContext()` when you need function lifecycle operations such as `create`, `update`, `get`, `getList`, `getMany`, or `delete`.
+
+## Related resources
+
+- [Function Decorators overview](/docs/nestjs-crud-automator/api-reference/decorators/api-function)
+- [`@ApiFunctionCustom`](/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-custom)
+- [Core Concepts – Services](/docs/nestjs-crud-automator/core-concepts/services)

--- a/docs/api-reference/decorators/api-function/page.mdx
+++ b/docs/api-reference/decorators/api-function/page.mdx
@@ -1,6 +1,6 @@
 # Function Decorators
 
-Function decorators wrap repository operations inside services, applying DTO validation, subscriber hooks, transaction boundaries, and standardized error handling for CRUD and custom service actions.
+CRUD and custom function decorators wrap repository operations inside services, applying DTO validation, subscriber hooks, transaction boundaries, and standardized error handling for CRUD and custom service actions. `@ApiFunctionStep` is the lightweight exception: it only wraps an internal helper with transaction context and does not run DTO validation, subscribers, action routing, Swagger, or authorization metadata.
 
 ## Available decorators
 
@@ -13,11 +13,12 @@ Function decorators wrap repository operations inside services, applying DTO val
 | `@ApiFunctionGet`     | Fetches a single entity instance with guard-friendly errors.                                        | [/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-get](/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-get)           |
 | `@ApiFunctionGetList` | Retrieves paginated collections with filtering, sorting, and projection metadata.                   | [/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-get-list](/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-get-list) |
 | `@ApiFunctionGetMany` | Optimized multi-record fetch that returns arrays, including empty results.                          | [/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-get-many](/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-get-many) |
+| `@ApiFunctionStep`    | Runs an internal transaction-aware service subroutine without action/subscriber/route metadata.     | [/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-step](/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-step)         |
 | `@ApiFunctionUpdate`  | Updates entities with DTO validation, ambient transaction support, and subscribers.                 | [/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-update](/docs/nestjs-crud-automator/api-reference/decorators/api-function/api-function-update)     |
 
 ## Transaction modes
 
-All built-in function decorators and `@ApiFunctionCustom` support `transaction.mode`:
+All built-in function decorators, `@ApiFunctionCustom`, and `@ApiFunctionStep` support `transaction.mode`. Step transaction modes only control transaction context for the helper body; they do not add subscriber, action, route, Swagger, or authorization metadata.
 
 ```typescript
 @ApiFunction<PostEntity>({
@@ -36,6 +37,8 @@ async createPost(properties: TApiFunctionCreateProperties<PostEntity>) {
 - `NONE` requires no active transaction and fails before the operation when one exists.
 
 Transaction managers are no longer public method arguments. Decorated methods keep clean signatures; subscribers receive the active manager on `context.DATA.eventManager`, and custom functions can use `this.getApiFunctionContext()` from `ApiServiceBase` to access `context.operations` and transactional repositories.
+
+Use `@ApiFunctionStep` for private/protected/public helper methods that need ApiFunction transaction semantics and context. A step is not a custom action: it does not create function subscriber hooks, route metadata, Swagger metadata, or authorization action identity. Inside a step, use `this.getApiFunctionStepContext()` for the active `eventManager`, entity `repository`, and `getRepository()`.
 
 ## Usage guidelines
 

--- a/docs/api-reference/interfaces/page.mdx
+++ b/docs/api-reference/interfaces/page.mdx
@@ -231,6 +231,33 @@ interface IApiFunctionContext<E extends IApiBaseEntity> {
 }
 ```
 
+### IApiFunctionStepContext\<E\>
+
+Narrow transaction-aware context available inside `@ApiFunctionStep`.
+
+```typescript
+interface IApiFunctionStepContext<E extends IApiBaseEntity> {
+	eventManager?: EntityManager;
+	getRepository: <T extends IApiBaseEntity>(entity: new () => T) => Repository<T>;
+	repository: Repository<E>;
+}
+```
+
+Step context intentionally does not expose `operations`; use `IApiFunctionContext` inside `@ApiFunctionCustom` when lifecycle operations are required.
+
+### IApiFunctionStepProperties\<E\>
+
+Configuration accepted by `@ApiFunctionStep`.
+
+```typescript
+interface IApiFunctionStepProperties<E extends IApiBaseEntity> {
+	entity: new (...arguments_: Array<unknown>) => E;
+	transaction?: {
+		mode: EApiFunctionTransactionMode;
+	};
+}
+```
+
 ### IApiFunctionContextOperations\<E\>
 
 Transaction-aware service operations exposed to `@ApiFunctionCustom`.

--- a/docs/core-concepts/services/page.mdx
+++ b/docs/core-concepts/services/page.mdx
@@ -222,6 +222,39 @@ export class PostService extends ApiServiceBase<PostEntity> {
 }
 ```
 
+Use `@ApiFunctionStep` for internal helper methods inside custom commands, generated or decorated service flows, or direct helper calls when the selected transaction mode permits. A step is useful when the helper needs ApiFunction transaction semantics and context but should not become a standalone custom action:
+
+```typescript filename="withdrawal.service.ts" copy
+import { ApiFunctionCustom, ApiFunctionStep, EApiFunctionTransactionMode } from "@elsikora/nestjs-crud-automator";
+
+@Injectable()
+export class WithdrawalService extends ApiServiceBase<WithdrawalEntity> {
+	@ApiFunctionCustom<WithdrawalEntity>({
+		action: "approve",
+		entity: WithdrawalEntity,
+		transaction: { mode: EApiFunctionTransactionMode.REQUIRED },
+	})
+	async approve(properties: IWithdrawalApproveProperties): Promise<WithdrawalEntity> {
+		return await this.releaseReservedWithdrawalAmount(properties);
+	}
+
+	@ApiFunctionStep<WithdrawalEntity>({
+		entity: WithdrawalEntity,
+		transaction: { mode: EApiFunctionTransactionMode.MANDATORY },
+	})
+	private async releaseReservedWithdrawalAmount(properties: IWithdrawalApproveProperties): Promise<WithdrawalEntity> {
+		const context = this.getApiFunctionStepContext<WithdrawalEntity>();
+
+		return await context.repository.save({
+			...properties.withdrawal,
+			state: "released",
+		});
+	}
+}
+```
+
+`@ApiFunctionStep` keeps normal method calls and does not require a context argument. It only provides transaction/context handling; it does not register a custom action, dispatch function subscribers, create route metadata, or expose Swagger/authorization metadata. Step context intentionally exposes only `eventManager`, `repository`, and `getRepository`; use `@ApiFunctionCustom` plus `getApiFunctionContext()` when you need `operations`.
+
 ## Observable Services
 
 Enable function-level subscribers by marking the service as observable:

--- a/src/class/api/function/context-storage.class.ts
+++ b/src/class/api/function/context-storage.class.ts
@@ -2,11 +2,10 @@ import type { AsyncLocalStorage } from "node:async_hooks";
 
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { IApiFunctionContext, IApiFunctionStepContext } from "@interface/class/api/function";
+import type { TApiFunctionContextStorageEntry } from "@type/class/api/function/context-storage-entry.type";
 import type { EntityManager } from "typeorm";
 
 import { AsyncLocalStorage as NodeAsyncLocalStorage } from "node:async_hooks";
-
-type TApiFunctionContextStorageEntry<E extends IApiBaseEntity> = { context: IApiFunctionContext<E>; kind: "function" } | { context: IApiFunctionStepContext<E>; kind: "step" };
 
 export class ApiFunctionContextStorage {
 	private static readonly STORAGE: AsyncLocalStorage<TApiFunctionContextStorageEntry<IApiBaseEntity>> = new NodeAsyncLocalStorage<TApiFunctionContextStorageEntry<IApiBaseEntity>>();
@@ -33,5 +32,15 @@ export class ApiFunctionContextStorage {
 
 	public static runStep<E extends IApiBaseEntity, R>(context: IApiFunctionStepContext<E>, callback: () => Promise<R>): Promise<R> {
 		return ApiFunctionContextStorage.STORAGE.run({ context, kind: "step" }, callback);
+	}
+
+	public static runWithoutStepContext<R>(callback: () => Promise<R>): Promise<R> {
+		const entry: TApiFunctionContextStorageEntry<IApiBaseEntity> | undefined = ApiFunctionContextStorage.STORAGE.getStore();
+
+		if (entry?.kind !== "step") {
+			return callback();
+		}
+
+		return ApiFunctionContextStorage.STORAGE.run({ context: { eventManager: entry.context.eventManager }, kind: "transaction" }, callback);
 	}
 }

--- a/src/class/api/function/context-storage.class.ts
+++ b/src/class/api/function/context-storage.class.ts
@@ -1,18 +1,37 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
-import type { IApiFunctionContext } from "@interface/class/api/function";
+import type { IApiFunctionContext, IApiFunctionStepContext } from "@interface/class/api/function";
+import type { EntityManager } from "typeorm";
 
 import { AsyncLocalStorage as NodeAsyncLocalStorage } from "node:async_hooks";
 
+type TApiFunctionContextStorageEntry<E extends IApiBaseEntity> = { context: IApiFunctionContext<E>; kind: "function" } | { context: IApiFunctionStepContext<E>; kind: "step" };
+
 export class ApiFunctionContextStorage {
-	private static readonly STORAGE: AsyncLocalStorage<IApiFunctionContext<IApiBaseEntity>> = new NodeAsyncLocalStorage<IApiFunctionContext<IApiBaseEntity>>();
+	private static readonly STORAGE: AsyncLocalStorage<TApiFunctionContextStorageEntry<IApiBaseEntity>> = new NodeAsyncLocalStorage<TApiFunctionContextStorageEntry<IApiBaseEntity>>();
 
 	public static get<E extends IApiBaseEntity>(): IApiFunctionContext<E> | undefined {
-		return ApiFunctionContextStorage.STORAGE.getStore() as IApiFunctionContext<E> | undefined;
+		const entry: TApiFunctionContextStorageEntry<IApiBaseEntity> | undefined = ApiFunctionContextStorage.STORAGE.getStore();
+
+		return entry?.kind === "function" ? (entry.context as unknown as IApiFunctionContext<E>) : undefined;
+	}
+
+	public static getEventManager(): EntityManager | undefined {
+		return ApiFunctionContextStorage.STORAGE.getStore()?.context.eventManager;
+	}
+
+	public static getStep<E extends IApiBaseEntity>(): IApiFunctionStepContext<E> | undefined {
+		const entry: TApiFunctionContextStorageEntry<IApiBaseEntity> | undefined = ApiFunctionContextStorage.STORAGE.getStore();
+
+		return entry?.kind === "step" ? (entry.context as IApiFunctionStepContext<E>) : undefined;
 	}
 
 	public static run<E extends IApiBaseEntity, R>(context: IApiFunctionContext<E>, callback: () => Promise<R>): Promise<R> {
-		return ApiFunctionContextStorage.STORAGE.run(context as unknown as IApiFunctionContext<IApiBaseEntity>, callback);
+		return ApiFunctionContextStorage.STORAGE.run({ context: context as unknown as IApiFunctionContext<IApiBaseEntity>, kind: "function" }, callback);
+	}
+
+	public static runStep<E extends IApiBaseEntity, R>(context: IApiFunctionStepContext<E>, callback: () => Promise<R>): Promise<R> {
+		return ApiFunctionContextStorage.STORAGE.run({ context, kind: "step" }, callback);
 	}
 }

--- a/src/class/api/function/custom-runtime.class.ts
+++ b/src/class/api/function/custom-runtime.class.ts
@@ -1,56 +1,28 @@
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { IApiFunctionContext } from "@interface/class/api/function";
 import type { IApiSubscriberFunctionErrorExecutionContext, IApiSubscriberFunctionExecutionContext, IApiSubscriberFunctionExecutionContextData } from "@interface/class/api/subscriber/function";
-import type { IApiGetListResponseResult } from "@interface/decorator/api";
 import type { IApiFunctionCustomProperties } from "@interface/decorator/api/function";
-import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateCriteria, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
 import type { EntityManager, Repository } from "typeorm";
 
 import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
+import { ApiFunctionServiceContextFactory } from "@class/api/function/service-context.factory.class";
 import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";
-import { EApiFunctionTransactionMode, EApiFunctionType, EApiSubscriberOnType } from "@enum/decorator/api";
-import { ErrorException } from "@utility/error/exception.utility";
+import { type EApiFunctionTransactionMode, EApiFunctionType, EApiSubscriberOnType } from "@enum/decorator/api";
+import { ApiFunctionExecuteWithTransaction } from "@utility/api/function-transaction.utility";
 
 export class ApiFunctionCustomRuntime {
 	public static async execute<E extends IApiBaseEntity>(options: { functionArguments: Array<unknown>; originalMethod: (...arguments_: Array<unknown>) => Promise<unknown>; properties: IApiFunctionCustomProperties<E>; target: { repository: Repository<E> }; transactionMode: EApiFunctionTransactionMode }): Promise<unknown> {
-		const activeContext: IApiFunctionContext<E> | undefined = ApiFunctionContextStorage.get<E>();
-		let eventManager: EntityManager | undefined;
-
-		try {
-			eventManager = ApiFunctionCustomRuntime.resolveEventManager(options.transactionMode, activeContext);
-		} catch (error) {
-			await ApiFunctionCustomRuntime.executeErrorSubscribers(options, undefined, EApiSubscriberOnType.BEFORE_ERROR, error);
-
-			throw error;
-		}
-
-		if (options.transactionMode === EApiFunctionTransactionMode.REQUIRED && !eventManager) {
-			return await options.target.repository.manager.transaction(async (transactionManager: EntityManager): Promise<unknown> => await ApiFunctionCustomRuntime.executeWithEventManager({ ...options, eventManager: transactionManager }));
-		}
-
-		return await ApiFunctionCustomRuntime.executeWithEventManager({ ...options, eventManager });
-	}
-
-	private static createContext<E extends IApiBaseEntity>(options: { eventManager?: EntityManager; properties: IApiFunctionCustomProperties<E>; target: { repository: Repository<E> } }): IApiFunctionContext<E> {
-		const repository: Repository<E> = options.eventManager?.getRepository(options.properties.entity) ?? options.target.repository;
-
-		return {
+		return await ApiFunctionExecuteWithTransaction({
+			callback: async (eventManager: EntityManager | undefined): Promise<unknown> => await ApiFunctionCustomRuntime.executeWithEventManager({ ...options, eventManager }),
 			entity: options.properties.entity,
-			eventManager: options.eventManager,
-			getRepository: <T extends IApiBaseEntity>(repositoryEntity: new () => T): Repository<T> => options.eventManager?.getRepository(repositoryEntity) ?? options.target.repository.manager.getRepository(repositoryEntity),
-			operations: {
-				create: async (properties: TApiFunctionCreateProperties<E>): Promise<E> => await (options.target as unknown as { create(properties: unknown): Promise<E> }).create(properties),
-				delete: async (criteria: Array<TApiFunctionDeleteCriteria<E>> | TApiFunctionDeleteCriteria<E>): Promise<void> => {
-					await (options.target as unknown as { delete(criteria: unknown): Promise<void> }).delete(criteria);
-				},
-				get: async (properties: TApiFunctionGetProperties<E>): Promise<E> => await (options.target as unknown as { get(properties: unknown): Promise<E> }).get(properties),
-				getList: async (properties: TApiFunctionGetListProperties<E>): Promise<IApiGetListResponseResult<E>> => await (options.target as unknown as { getList(properties: unknown): Promise<IApiGetListResponseResult<E>> }).getList(properties),
-				getMany: async (properties: TApiFunctionGetManyProperties<E>): Promise<Array<E>> => await (options.target as unknown as { getMany(properties: unknown): Promise<Array<E>> }).getMany(properties),
-				getRepository: <T extends IApiBaseEntity>(repositoryEntity: new () => T): Repository<T> => options.eventManager?.getRepository(repositoryEntity) ?? options.target.repository.manager.getRepository(repositoryEntity),
-				update: async (criteria: Array<TApiFunctionUpdateCriteria<E>> | TApiFunctionUpdateCriteria<E>, properties: TApiFunctionUpdateProperties<E>): Promise<E> => await (options.target as unknown as { update(criteria: unknown, properties: unknown): Promise<E> }).update(criteria, properties),
+			label: "ApiFunctionCustom",
+			mode: options.transactionMode,
+			onPreflightError: async (eventManager: EntityManager | undefined, error: Error): Promise<void> => {
+				await ApiFunctionCustomRuntime.executeErrorSubscribers(options, eventManager, EApiSubscriberOnType.BEFORE_ERROR, error);
 			},
-			repository,
-		};
+			repository: options.target.repository,
+			shouldBindTransactionScope: false,
+		});
 	}
 
 	private static async executeErrorSubscribers<E extends IApiBaseEntity>(options: { eventManager?: EntityManager; properties: IApiFunctionCustomProperties<E>; target: { repository: Repository<E> } }, eventManager: EntityManager | undefined, onType: EApiSubscriberOnType, error: unknown): Promise<void> {
@@ -68,7 +40,12 @@ export class ApiFunctionCustomRuntime {
 
 	private static async executeWithEventManager<E extends IApiBaseEntity>(options: { eventManager?: EntityManager; functionArguments: Array<unknown>; originalMethod: (...arguments_: Array<unknown>) => Promise<unknown>; properties: IApiFunctionCustomProperties<E>; target: { repository: Repository<E> } }): Promise<unknown> {
 		const entityInstance: E = new options.properties.entity();
-		const context: IApiFunctionContext<E> = ApiFunctionCustomRuntime.createContext(options);
+
+		const context: IApiFunctionContext<E> = ApiFunctionServiceContextFactory.create({
+			entity: options.properties.entity,
+			eventManager: options.eventManager,
+			target: options.target,
+		});
 
 		const executionContext: IApiSubscriberFunctionExecutionContext<E, Array<unknown>, IApiSubscriberFunctionExecutionContextData<E>> = {
 			action: options.properties.action,
@@ -105,17 +82,5 @@ export class ApiFunctionCustomRuntime {
 
 			throw error;
 		}
-	}
-
-	private static resolveEventManager<E extends IApiBaseEntity>(transactionMode: EApiFunctionTransactionMode, activeContext?: IApiFunctionContext<E>): EntityManager | undefined {
-		if (transactionMode === EApiFunctionTransactionMode.NONE && activeContext?.eventManager) {
-			throw ErrorException("ApiFunctionCustom transaction mode NONE cannot run inside an active transaction");
-		}
-
-		if (transactionMode === EApiFunctionTransactionMode.MANDATORY && !activeContext?.eventManager) {
-			throw ErrorException("ApiFunctionCustom transaction mode MANDATORY requires an active transaction");
-		}
-
-		return transactionMode === EApiFunctionTransactionMode.NONE ? undefined : activeContext?.eventManager;
 	}
 }

--- a/src/class/api/function/service-context.factory.class.ts
+++ b/src/class/api/function/service-context.factory.class.ts
@@ -1,0 +1,97 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { IApiFunctionContext, IApiFunctionStepContext } from "@interface/class/api/function";
+import type { IApiGetListResponseResult } from "@interface/decorator/api";
+import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateCriteria, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
+import type { EntityManager, Repository } from "typeorm";
+
+import { ErrorException } from "@utility/error/exception.utility";
+
+export class ApiFunctionServiceContextFactory {
+	/**
+	 * Creates a service-bound ApiFunction context for custom functions and internal steps.
+	 * @template E - Entity type associated with the decorated function or step.
+	 * @param {object} options - Context creation options.
+	 * @param {new (...arguments_: Array<unknown>) => E} options.entity - Entity constructor associated with the service context.
+	 * @param {EntityManager} [options.eventManager] - Active transaction manager, when available.
+	 * @param {{ repository?: Repository<E> }} options.target - Service instance that owns the decorated method.
+	 * @param {Repository<E>} [options.target.repository] - Service repository used to resolve non-transactional repositories.
+	 * @returns {IApiFunctionContext<E>} Service-bound function context.
+	 */
+	public static create<E extends IApiBaseEntity>(options: { entity: new (...arguments_: Array<unknown>) => E; eventManager?: EntityManager; target: { repository?: Repository<E> } }): IApiFunctionContext<E> {
+		const repository: Repository<E> | undefined = options.eventManager?.getRepository(options.entity) ?? ApiFunctionServiceContextFactory.resolveManagerRepository(options.target, options.entity);
+
+		if (!repository) {
+			throw ErrorException("Repository is not available in this context");
+		}
+
+		return {
+			entity: options.entity,
+			eventManager: options.eventManager,
+			getRepository: <T extends IApiBaseEntity>(repositoryEntity: new () => T): Repository<T> => options.eventManager?.getRepository(repositoryEntity) ?? ApiFunctionServiceContextFactory.getManagerRepository(options.target, repositoryEntity),
+			operations: {
+				create: async (properties: TApiFunctionCreateProperties<E>): Promise<E> => await (options.target as unknown as { create(properties: unknown): Promise<E> }).create(properties),
+				delete: async (criteria: Array<TApiFunctionDeleteCriteria<E>> | TApiFunctionDeleteCriteria<E>): Promise<void> => {
+					await (options.target as unknown as { delete(criteria: unknown): Promise<void> }).delete(criteria);
+				},
+				get: async (properties: TApiFunctionGetProperties<E>): Promise<E> => await (options.target as unknown as { get(properties: unknown): Promise<E> }).get(properties),
+				getList: async (properties: TApiFunctionGetListProperties<E>): Promise<IApiGetListResponseResult<E>> => await (options.target as unknown as { getList(properties: unknown): Promise<IApiGetListResponseResult<E>> }).getList(properties),
+				getMany: async (properties: TApiFunctionGetManyProperties<E>): Promise<Array<E>> => await (options.target as unknown as { getMany(properties: unknown): Promise<Array<E>> }).getMany(properties),
+				getRepository: <T extends IApiBaseEntity>(repositoryEntity: new () => T): Repository<T> => options.eventManager?.getRepository(repositoryEntity) ?? ApiFunctionServiceContextFactory.getManagerRepository(options.target, repositoryEntity),
+				update: async (criteria: Array<TApiFunctionUpdateCriteria<E>> | TApiFunctionUpdateCriteria<E>, properties: TApiFunctionUpdateProperties<E>): Promise<E> => await (options.target as unknown as { update(criteria: unknown, properties: unknown): Promise<E> }).update(criteria, properties),
+			},
+			repository,
+		};
+	}
+
+	/**
+	 * Creates a narrow service-bound ApiFunctionStep context.
+	 * @template E - Entity type associated with the decorated step.
+	 * @param {object} options - Context creation options.
+	 * @param {new (...arguments_: Array<unknown>) => E} options.entity - Entity constructor associated with the step context.
+	 * @param {EntityManager} [options.eventManager] - Active transaction manager, when available.
+	 * @param {{ repository?: Repository<E> }} options.target - Service instance that owns the decorated step.
+	 * @param {Repository<E>} [options.target.repository] - Service repository used to resolve non-transactional repositories.
+	 * @returns {IApiFunctionStepContext<E>} Service-bound step context.
+	 */
+	public static createStep<E extends IApiBaseEntity>(options: { entity: new (...arguments_: Array<unknown>) => E; eventManager?: EntityManager; target: { repository?: Repository<E> } }): IApiFunctionStepContext<E> {
+		const repository: Repository<E> | undefined = options.eventManager?.getRepository(options.entity) ?? ApiFunctionServiceContextFactory.resolveManagerRepository(options.target, options.entity);
+
+		if (!repository) {
+			throw ErrorException("Repository is not available in this context");
+		}
+
+		return {
+			eventManager: options.eventManager,
+			getRepository: <T extends IApiBaseEntity>(repositoryEntity: new () => T): Repository<T> => options.eventManager?.getRepository(repositoryEntity) ?? ApiFunctionServiceContextFactory.getManagerRepository(options.target, repositoryEntity),
+			repository,
+		};
+	}
+
+	/**
+	 * Resolves repositories from the service repository manager when no transaction manager is active.
+	 * @template T - Repository entity type.
+	 * @param {{ repository?: Repository<IApiBaseEntity> }} target - Service instance with an optional repository.
+	 * @param {Repository<IApiBaseEntity>} [target.repository] - Service repository used to resolve repositories.
+	 * @param {new () => T} entity - Entity constructor to resolve.
+	 * @returns {Repository<T>} Repository from the service manager.
+	 */
+	private static getManagerRepository<T extends IApiBaseEntity>(target: { repository?: Repository<IApiBaseEntity> }, entity: new () => T): Repository<T> {
+		if (!target.repository) {
+			throw ErrorException("Repository is not available in this context");
+		}
+
+		return target.repository.manager.getRepository(entity);
+	}
+
+	/**
+	 * Resolves a repository from the service repository manager if a service repository exists.
+	 * @template T - Repository entity type.
+	 * @param {{ repository?: Repository<IApiBaseEntity> }} target - Service instance with an optional repository.
+	 * @param {Repository<IApiBaseEntity>} [target.repository] - Service repository used to resolve repositories.
+	 * @param {new () => T} entity - Entity constructor to resolve.
+	 * @returns {Repository<T> | undefined} Repository from the service manager, when available.
+	 */
+	private static resolveManagerRepository<T extends IApiBaseEntity>(target: { repository?: Repository<IApiBaseEntity> }, entity: new () => T): Repository<T> | undefined {
+		return target.repository?.manager.getRepository(entity);
+	}
+}

--- a/src/class/api/function/step-runtime.class.ts
+++ b/src/class/api/function/step-runtime.class.ts
@@ -1,0 +1,40 @@
+import type { EApiFunctionTransactionMode } from "@enum/decorator/api";
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { IApiFunctionStepContext } from "@interface/class/api/function";
+import type { IApiFunctionStepProperties } from "@interface/decorator/api/function/step-properties.interface";
+import type { EntityManager, Repository } from "typeorm";
+
+import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
+import { ApiFunctionServiceContextFactory } from "@class/api/function/service-context.factory.class";
+import { ApiFunctionExecuteWithTransaction } from "@utility/api/function-transaction.utility";
+
+export class ApiFunctionStepRuntime {
+	/**
+	 * Executes an internal function step with Automator transaction semantics.
+	 * @template E - Entity type associated with the decorated step.
+	 * @param {object} options - Step execution options.
+	 * @param {Array<unknown>} options.functionArguments - Original method arguments.
+	 * @param {(...arguments_: Array<unknown>) => Promise<unknown>} options.originalMethod - Original step method.
+	 * @param {IApiFunctionStepProperties<E>} options.properties - Step configuration.
+	 * @param {{ repository?: Repository<E> }} options.target - Service instance that owns the step.
+	 * @param {EApiFunctionTransactionMode} options.transactionMode - Resolved transaction mode.
+	 * @returns {Promise<unknown>} Original step result.
+	 */
+	public static async execute<E extends IApiBaseEntity>(options: { functionArguments: Array<unknown>; originalMethod: (...arguments_: Array<unknown>) => Promise<unknown>; properties: IApiFunctionStepProperties<E>; target: { repository?: Repository<E> }; transactionMode: EApiFunctionTransactionMode }): Promise<unknown> {
+		return await ApiFunctionExecuteWithTransaction({
+			callback: async (eventManager: EntityManager | undefined): Promise<unknown> => {
+				const context: IApiFunctionStepContext<E> = ApiFunctionServiceContextFactory.createStep({
+					entity: options.properties.entity,
+					eventManager,
+					target: options.target,
+				});
+
+				return await ApiFunctionContextStorage.runStep(context, async (): Promise<unknown> => await options.originalMethod.apply(options.target, options.functionArguments));
+			},
+			entity: options.properties.entity,
+			label: "ApiFunctionStep",
+			mode: options.transactionMode,
+			repository: options.target.repository,
+		});
+	}
+}

--- a/src/class/api/service-base.class.ts
+++ b/src/class/api/service-base.class.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @elsikora/sonar/void-use */
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
-import type { IApiFunctionContext } from "@interface/class/api/function";
+import type { IApiFunctionContext, IApiFunctionStepContext } from "@interface/class/api/function";
 import type { IApiGetListResponseResult } from "@interface/decorator/api";
 import type { TApiFunctionCreateProperties, TApiFunctionDeleteCriteria, TApiFunctionGetListProperties, TApiFunctionGetManyProperties, TApiFunctionGetProperties, TApiFunctionUpdateCriteria, TApiFunctionUpdateProperties } from "@type/decorator/api/function";
 
@@ -54,8 +54,22 @@ export class ApiServiceBase<E> {
 	protected getApiFunctionContext<T extends IApiBaseEntity>(): IApiFunctionContext<T> {
 		const context: IApiFunctionContext<T> | undefined = ApiFunctionContextStorage.get<T>();
 
+		if (!context && ApiFunctionContextStorage.getStep<T>()) {
+			throw ErrorException("Api function context is not available inside a decorated ApiFunctionStep execution");
+		}
+
 		if (!context) {
 			throw ErrorException("Api function context is not available outside a decorated ApiFunction execution");
+		}
+
+		return context;
+	}
+
+	protected getApiFunctionStepContext<T extends IApiBaseEntity>(): IApiFunctionStepContext<T> {
+		const context: IApiFunctionStepContext<T> | undefined = ApiFunctionContextStorage.getStep<T>();
+
+		if (!context) {
+			throw ErrorException("Api function step context is not available outside a decorated ApiFunctionStep execution");
 		}
 
 		return context;

--- a/src/class/api/subscriber/executor.class.ts
+++ b/src/class/api/subscriber/executor.class.ts
@@ -7,6 +7,7 @@ import type { IApiSubscriberFunctionExecutionContext } from "@interface/class/ap
 import type { IApiSubscriberRouteErrorExecutionContext } from "@interface/class/api/subscriber/route/error-execution-context.interface";
 import type { IApiSubscriberRouteExecutionContext } from "@interface/class/api/subscriber/route/execution/context";
 
+import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
 import { CONTROLLER_API_DECORATOR_CONSTANT } from "@constant/decorator/api/controller.constant";
 import { SERVICE_API_DECORATOR_CONSTANT } from "@constant/decorator/api/service.constant";
 import { EApiFunctionType } from "@enum/decorator/api/function-type.enum";
@@ -26,15 +27,17 @@ export class ApiSubscriberExecutor {
 		const entityName: string = ApiSubscriberExecutor.resolveEntityName(entity, context);
 		const subscribers: Array<IApiSubscriberFunction<IApiBaseEntity>> = apiSubscriberRegistry.getFunctionSubscribers(entityName, functionType, action ?? context.action);
 
-		for (const subscriber of subscribers) {
-			const hookName: string = ApiSubscriberExecutor.resolveHookName(onType, functionType);
-			const hook: unknown = subscriber[hookName as keyof IApiSubscriberFunction<IApiBaseEntity>];
+		await ApiFunctionContextStorage.runWithoutStepContext(async (): Promise<void> => {
+			for (const subscriber of subscribers) {
+				const hookName: string = ApiSubscriberExecutor.resolveHookName(onType, functionType);
+				const hook: unknown = subscriber[hookName as keyof IApiSubscriberFunction<IApiBaseEntity>];
 
-			if (typeof hook === "function") {
-				subscriberLogger.verbose(`Executing function error hook ${hookName} from ${subscriber.constructor.name} for entity ${entityName}`);
-				await hook.call(subscriber, context, error);
+				if (typeof hook === "function") {
+					subscriberLogger.verbose(`Executing function error hook ${hookName} from ${subscriber.constructor.name} for entity ${entityName}`);
+					await hook.call(subscriber, context, error);
+				}
 			}
-		}
+		});
 	}
 
 	public static async executeFunctionSubscribers<E extends IApiBaseEntity, TResult, TInput>(constructor: new (...arguments_: Array<unknown>) => unknown, entity: E, functionType: EApiFunctionType, onType: EApiSubscriberOnType, context: IApiSubscriberFunctionExecutionContext<E, TResult, TInput>, action?: string): Promise<TResult | undefined> {
@@ -46,19 +49,21 @@ export class ApiSubscriberExecutor {
 		const subscribers: Array<IApiSubscriberFunction<IApiBaseEntity>> = apiSubscriberRegistry.getFunctionSubscribers(entityName, functionType, action ?? context.action);
 		let result: TResult | undefined = context.result;
 
-		for (const subscriber of subscribers) {
-			const hookName: string = ApiSubscriberExecutor.resolveHookName(onType, functionType);
-			const hook: unknown = subscriber[hookName as keyof IApiSubscriberFunction<IApiBaseEntity>];
+		await ApiFunctionContextStorage.runWithoutStepContext(async (): Promise<void> => {
+			for (const subscriber of subscribers) {
+				const hookName: string = ApiSubscriberExecutor.resolveHookName(onType, functionType);
+				const hook: unknown = subscriber[hookName as keyof IApiSubscriberFunction<IApiBaseEntity>];
 
-			if (typeof hook === "function") {
-				subscriberLogger.verbose(`Executing function hook ${hookName} from ${subscriber.constructor.name} for entity ${entityName}`);
-				const hookResult: TResult | undefined = (await hook.call(subscriber, { ...context, result })) as TResult | undefined;
+				if (typeof hook === "function") {
+					subscriberLogger.verbose(`Executing function hook ${hookName} from ${subscriber.constructor.name} for entity ${entityName}`);
+					const hookResult: TResult | undefined = (await hook.call(subscriber, { ...context, result })) as TResult | undefined;
 
-				if (hookResult !== undefined) {
-					result = hookResult;
+					if (hookResult !== undefined) {
+						result = hookResult;
+					}
 				}
 			}
-		}
+		});
 
 		return result;
 	}

--- a/src/decorator/api/function/create.decorator.ts
+++ b/src/decorator/api/function/create.decorator.ts
@@ -101,7 +101,7 @@ export function ApiFunctionCreate<E extends IApiBaseEntity>(properties: IApiFunc
  */
 async function executor<E extends IApiBaseEntity>(options: IApiFunctionCreateExecutorProperties<E>): Promise<E> {
 	const { constructor, entity, properties, repository }: IApiFunctionCreateExecutorProperties<E> = options;
-	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
 
 	try {
 		let result: E;

--- a/src/decorator/api/function/delete.decorator.ts
+++ b/src/decorator/api/function/delete.decorator.ts
@@ -112,7 +112,7 @@ export function ApiFunctionDelete<E extends IApiBaseEntity>(properties: IApiFunc
  */
 async function executor<E extends IApiBaseEntity>(options: IApiFunctionDeleteExecutorProperties<E>): Promise<E> {
 	const { constructor, criteria, entity, getFunction, repository }: IApiFunctionDeleteExecutorProperties<E> = options;
-	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
 
 	try {
 		const existingEntity: E = await getFunction({ where: criteria });

--- a/src/decorator/api/function/get/decorator.ts
+++ b/src/decorator/api/function/get/decorator.ts
@@ -100,7 +100,7 @@ export function ApiFunctionGet<E extends IApiBaseEntity>(properties: IApiFunctio
  */
 async function executor<E extends IApiBaseEntity>(options: IApiFunctionGetExecutorProperties<E>): Promise<E> {
 	const { constructor, entity, properties, repository }: IApiFunctionGetExecutorProperties<E> = options;
-	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
 
 	try {
 		let item: E | null;

--- a/src/decorator/api/function/get/list.decorator.ts
+++ b/src/decorator/api/function/get/list.decorator.ts
@@ -114,7 +114,7 @@ function calculateCurrentPage<E extends IApiBaseEntity>(properties: TApiFunction
  */
 async function executor<E extends IApiBaseEntity>(options: IApiFunctionGetListExecutorProperties<E>): Promise<IApiGetListResponseResult<E>> {
 	const { constructor, entity, properties, repository }: IApiFunctionGetListExecutorProperties<E> = options;
-	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
 
 	try {
 		let items: Array<E>;

--- a/src/decorator/api/function/get/many.decorator.ts
+++ b/src/decorator/api/function/get/many.decorator.ts
@@ -100,7 +100,7 @@ export function ApiFunctionGetMany<E extends IApiBaseEntity>(properties: IApiFun
  */
 async function executor<E extends IApiBaseEntity>(options: IApiFunctionGetManyExecutorProperties<E>): Promise<Array<E>> {
 	const { constructor, entity, properties, repository }: IApiFunctionGetManyExecutorProperties<E> = options;
-	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
 
 	try {
 		let items: Array<E>;

--- a/src/decorator/api/function/index.ts
+++ b/src/decorator/api/function/index.ts
@@ -3,4 +3,5 @@ export { ApiFunctionCustom } from "./custom.decorator";
 export { ApiFunction } from "./decorator";
 export { ApiFunctionDelete } from "./delete.decorator";
 export * from "./get";
+export { ApiFunctionStep } from "./step.decorator";
 export { ApiFunctionUpdate } from "./update.decorator";

--- a/src/decorator/api/function/step.decorator.ts
+++ b/src/decorator/api/function/step.decorator.ts
@@ -1,0 +1,32 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { IApiFunctionStepProperties } from "@interface/decorator/api/function/step-properties.interface";
+import type { Repository } from "typeorm";
+
+import { ApiFunctionStepRuntime } from "@class/api/function/step-runtime.class";
+import { EApiFunctionTransactionMode } from "@enum/decorator/api";
+
+/**
+ * Creates a decorator for internal transaction-aware ApiFunction steps.
+ * @template E - Entity type handled by the decorated service.
+ * @param {IApiFunctionStepProperties<E>} properties - Step transaction and entity configuration.
+ * @returns {(target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor} A method decorator that wraps the original function.
+ */
+export function ApiFunctionStep<E extends IApiBaseEntity>(properties: IApiFunctionStepProperties<E>): (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor {
+	const transactionMode: EApiFunctionTransactionMode = properties.transaction?.mode ?? EApiFunctionTransactionMode.SUPPORTS;
+
+	return function (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor): PropertyDescriptor {
+		const originalMethod: (...arguments_: Array<unknown>) => Promise<unknown> = descriptor.value as (...arguments_: Array<unknown>) => Promise<unknown>;
+
+		descriptor.value = async function (this: { repository?: Repository<E> }, ...functionArguments: Array<unknown>): Promise<unknown> {
+			return await ApiFunctionStepRuntime.execute({
+				functionArguments,
+				originalMethod,
+				properties,
+				target: this,
+				transactionMode,
+			});
+		};
+
+		return descriptor;
+	};
+}

--- a/src/decorator/api/function/update.decorator.ts
+++ b/src/decorator/api/function/update.decorator.ts
@@ -114,7 +114,7 @@ export function ApiFunctionUpdate<E extends IApiBaseEntity>(properties: IApiFunc
  */
 async function executor<E extends IApiBaseEntity>(options: IApiFunctionUpdateExecutorProperties<E>): Promise<E> {
 	const { constructor, criteria, entity, getFunction, properties, repository }: IApiFunctionUpdateExecutorProperties<E> = options;
-	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+	const eventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
 
 	try {
 		const existingEntity: E = await getFunction({ where: criteria });

--- a/src/interface/class/api/function/context/index.ts
+++ b/src/interface/class/api/function/context/index.ts
@@ -1,2 +1,3 @@
 export { type IApiFunctionContext } from "./interface";
 export { type IApiFunctionContextOperations } from "./operations.interface";
+export { type IApiFunctionStepContext } from "./step.interface";

--- a/src/interface/class/api/function/context/step.interface.ts
+++ b/src/interface/class/api/function/context/step.interface.ts
@@ -1,0 +1,8 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { EntityManager, Repository } from "typeorm";
+
+export interface IApiFunctionStepContext<E extends IApiBaseEntity> {
+	eventManager?: EntityManager;
+	getRepository: <T extends IApiBaseEntity>(entity: new () => T) => Repository<T>;
+	repository: Repository<E>;
+}

--- a/src/interface/decorator/api/function/index.ts
+++ b/src/interface/decorator/api/function/index.ts
@@ -3,4 +3,5 @@ export { type IApiFunctionCustomProperties } from "./custom-properties.interface
 export { type IApiFunctionDeleteExecutorProperties } from "./delete-executor-properties.interface";
 export type * from "./get";
 export { type IApiFunctionProperties } from "./properties.interface";
+export { type IApiFunctionStepProperties } from "./step-properties.interface";
 export { type IApiFunctionUpdateExecutorProperties } from "./update-executor-properties.interface";

--- a/src/interface/decorator/api/function/step-properties.interface.ts
+++ b/src/interface/decorator/api/function/step-properties.interface.ts
@@ -1,0 +1,9 @@
+import type { EApiFunctionTransactionMode } from "@enum/decorator/api";
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+
+export interface IApiFunctionStepProperties<E extends IApiBaseEntity> {
+	entity: new (...arguments_: Array<unknown>) => E;
+	transaction?: {
+		mode: EApiFunctionTransactionMode;
+	};
+}

--- a/src/type/class/api/function/context-storage-entry.type.ts
+++ b/src/type/class/api/function/context-storage-entry.type.ts
@@ -1,0 +1,5 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { IApiFunctionContext, IApiFunctionStepContext } from "@interface/class/api/function";
+import type { EntityManager } from "typeorm";
+
+export type TApiFunctionContextStorageEntry<E extends IApiBaseEntity> = { context: { eventManager?: EntityManager }; kind: "transaction" } | { context: IApiFunctionContext<E>; kind: "function" } | { context: IApiFunctionStepContext<E>; kind: "step" };

--- a/src/utility/api/function-transaction.utility.ts
+++ b/src/utility/api/function-transaction.utility.ts
@@ -13,16 +13,19 @@ import { ErrorException } from "@utility/error/exception.utility";
  * @param {object} options - Transaction execution options.
  * @param {(eventManager: EntityManager | undefined) => Promise<R>} options.callback - Function body to run with the resolved transaction manager.
  * @param {new (...arguments_: Array<unknown>) => E} options.entity - Entity constructor associated with the function.
+ * @param {string} [options.label] - Error message label for the decorated function primitive.
  * @param {EApiFunctionTransactionMode} options.mode - Transaction mode to enforce.
  * @param {(eventManager: EntityManager | undefined, error: Error) => Promise<void>} [options.onPreflightError] - Error hook for transaction mode conflicts before the function body starts.
  * @param {Repository<E>} [options.repository] - Repository used to open new transactions when required.
+ * @param {boolean} [options.shouldBindTransactionScope] - Whether REQUIRED-created transactions should install an ApiFunctionTransactionScope context.
  * @returns {Promise<R>} Callback result.
  */
-export async function ApiFunctionExecuteWithTransaction<E extends IApiBaseEntity, R>(options: { callback: (eventManager: EntityManager | undefined) => Promise<R>; entity: new (...arguments_: Array<unknown>) => E; mode: EApiFunctionTransactionMode; onPreflightError?: (eventManager: EntityManager | undefined, error: Error) => Promise<void>; repository?: Repository<E> }): Promise<R> {
-	const activeEventManager: EntityManager | undefined = ApiFunctionContextStorage.get<E>()?.eventManager;
+export async function ApiFunctionExecuteWithTransaction<E extends IApiBaseEntity, R>(options: { callback: (eventManager: EntityManager | undefined) => Promise<R>; entity: new (...arguments_: Array<unknown>) => E; label?: string; mode: EApiFunctionTransactionMode; onPreflightError?: (eventManager: EntityManager | undefined, error: Error) => Promise<void>; repository?: Repository<E>; shouldBindTransactionScope?: boolean }): Promise<R> {
+	const activeEventManager: EntityManager | undefined = ApiFunctionContextStorage.getEventManager();
+	const label: string = options.label ?? "ApiFunction";
 
 	if (options.mode === EApiFunctionTransactionMode.NONE && activeEventManager) {
-		const error: Error = ErrorException("ApiFunction transaction mode NONE cannot run inside an active transaction");
+		const error: Error = ErrorException(`${label} transaction mode NONE cannot run inside an active transaction`);
 
 		await options.onPreflightError?.(activeEventManager, error);
 
@@ -30,7 +33,7 @@ export async function ApiFunctionExecuteWithTransaction<E extends IApiBaseEntity
 	}
 
 	if (options.mode === EApiFunctionTransactionMode.MANDATORY && !activeEventManager) {
-		const error: Error = ErrorException("ApiFunction transaction mode MANDATORY requires an active transaction");
+		const error: Error = ErrorException(`${label} transaction mode MANDATORY requires an active transaction`);
 
 		await options.onPreflightError?.(undefined, error);
 
@@ -48,7 +51,13 @@ export async function ApiFunctionExecuteWithTransaction<E extends IApiBaseEntity
 			throw error;
 		}
 
-		return await options.repository.manager.transaction(async (transactionManager: EntityManager): Promise<R> => await ApiFunctionTransactionScope.runWithEntityManager(transactionManager, async (): Promise<R> => await options.callback(transactionManager)));
+		return await options.repository.manager.transaction(async (transactionManager: EntityManager): Promise<R> => {
+			if (options.shouldBindTransactionScope === false) {
+				return await options.callback(transactionManager);
+			}
+
+			return await ApiFunctionTransactionScope.runWithEntityManager(transactionManager, async (): Promise<R> => await options.callback(transactionManager));
+		});
 	}
 
 	return await options.callback(eventManager);

--- a/test/e2e/app/function/controller.ts
+++ b/test/e2e/app/function/controller.ts
@@ -49,6 +49,26 @@ export class E2eFunctionController {
 		return await this.service.createWithCustomNoneInsideTransaction(body);
 	}
 
+	@Post("custom-step")
+	public async customStep(@Body() body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.service.createWithCustomStep(body);
+	}
+
+	@Post("custom-step-rollback")
+	public async customStepRollback(@Body() body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.service.createWithFailingCustomStep(body);
+	}
+
+	@Post("custom-step-generated")
+	public async customStepGenerated(@Body() body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.service.createWithStepGeneratedFunction(body);
+	}
+
+	@Post("custom-step-custom")
+	public async customStepCustom(@Body() body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.service.createWithStepCustomFunction(body);
+	}
+
 	@Post("custom-required")
 	public async customRequired(@Body() body: Partial<E2eEntity>): Promise<E2eEntity> {
 		return await this.service.createWithCustomRequired(body);

--- a/test/e2e/app/service.ts
+++ b/test/e2e/app/service.ts
@@ -3,7 +3,7 @@ import type { DataSource, Repository } from "typeorm";
 import { Injectable } from "@nestjs/common";
 import { InjectDataSource, InjectRepository } from "@nestjs/typeorm";
 
-import { ApiFunction, ApiFunctionCustom, ApiFunctionTransactionScope, ApiService, ApiServiceBase, ApiServiceObservable, EApiFunctionTransactionMode, EApiFunctionType } from "../../../src/index";
+import { ApiFunction, ApiFunctionCustom, ApiFunctionStep, ApiFunctionTransactionScope, ApiService, ApiServiceBase, ApiServiceObservable, EApiFunctionTransactionMode, EApiFunctionType } from "../../../src/index";
 
 import { E2eEntity } from "./entity";
 
@@ -69,6 +69,50 @@ export class E2eService extends ApiServiceBase<E2eEntity> {
 		return await this.getApiFunctionContext<E2eEntity>().operations.create(body);
 	}
 
+	@ApiFunctionCustom<E2eEntity>({
+		action: "custom.step",
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.REQUIRED,
+		},
+	})
+	public async createWithCustomStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.createWithMandatoryStep(body);
+	}
+
+	@ApiFunctionCustom<E2eEntity>({
+		action: "custom.step.rollback",
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.REQUIRED,
+		},
+	})
+	public async createWithFailingCustomStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.createWithFailingMandatoryStep(body);
+	}
+
+	@ApiFunctionCustom<E2eEntity>({
+		action: "custom.step.generated",
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.REQUIRED,
+		},
+	})
+	public async createWithStepGeneratedFunction(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.createWithGeneratedFunctionStep(body);
+	}
+
+	@ApiFunctionCustom<E2eEntity>({
+		action: "custom.step.custom",
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.REQUIRED,
+		},
+	})
+	public async createWithStepCustomFunction(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.createWithNestedCustomFunctionStep(body);
+	}
+
 	public async createWithCustomNoneInsideTransaction(body: Partial<E2eEntity>): Promise<E2eEntity> {
 		return await ApiFunctionTransactionScope.runWithDataSource(this.dataSource, async () => await this.createWithCustomNone(body));
 	}
@@ -119,5 +163,67 @@ export class E2eService extends ApiServiceBase<E2eEntity> {
 
 	public async createWithBuiltinNoneInsideTransaction(body: Partial<E2eEntity>): Promise<E2eEntity> {
 		return await ApiFunctionTransactionScope.runWithDataSource(this.dataSource, async () => await this.createWithBuiltinNone(body));
+	}
+
+	@ApiFunctionStep<E2eEntity>({
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.MANDATORY,
+		},
+	})
+	private async createWithMandatoryStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		const context = this.getApiFunctionStepContext<E2eEntity>();
+
+		if (!context.eventManager) {
+			throw new Error("Step transaction manager is required");
+		}
+
+		return await context.repository.save({
+			...body,
+			name: `step-${body.name ?? ""}`,
+		});
+	}
+
+	@ApiFunctionStep<E2eEntity>({
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.MANDATORY,
+		},
+	})
+	private async createWithFailingMandatoryStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		const context = this.getApiFunctionStepContext<E2eEntity>();
+
+		await context.repository.save({
+			...body,
+			name: `rollback-${body.name ?? ""}`,
+		});
+
+		throw new Error("Forced function step failure");
+	}
+
+	@ApiFunctionStep<E2eEntity>({
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.MANDATORY,
+		},
+	})
+	private async createWithGeneratedFunctionStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.create({
+			...body,
+			name: `generated-step-${body.name ?? ""}`,
+		});
+	}
+
+	@ApiFunctionStep<E2eEntity>({
+		entity: E2eEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.MANDATORY,
+		},
+	})
+	private async createWithNestedCustomFunctionStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
+		return await this.createWithCustomMandatory({
+			...body,
+			name: `nested-step-${body.name ?? ""}`,
+		});
 	}
 }

--- a/test/e2e/app/service.ts
+++ b/test/e2e/app/service.ts
@@ -208,10 +208,18 @@ export class E2eService extends ApiServiceBase<E2eEntity> {
 		},
 	})
 	private async createWithGeneratedFunctionStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
-		return await this.create({
+		const beforeContext = this.getApiFunctionStepContext<E2eEntity>();
+		const result = await this.create({
 			...body,
 			name: `generated-step-${body.name ?? ""}`,
 		});
+		const afterContext = this.getApiFunctionStepContext<E2eEntity>();
+
+		if (beforeContext !== afterContext) {
+			throw new Error("Step context was not restored after generated function call");
+		}
+
+		return result;
 	}
 
 	@ApiFunctionStep<E2eEntity>({
@@ -221,9 +229,17 @@ export class E2eService extends ApiServiceBase<E2eEntity> {
 		},
 	})
 	private async createWithNestedCustomFunctionStep(body: Partial<E2eEntity>): Promise<E2eEntity> {
-		return await this.createWithCustomMandatory({
+		const beforeContext = this.getApiFunctionStepContext<E2eEntity>();
+		const result = await this.createWithCustomMandatory({
 			...body,
 			name: `nested-step-${body.name ?? ""}`,
 		});
+		const afterContext = this.getApiFunctionStepContext<E2eEntity>();
+
+		if (beforeContext !== afterContext) {
+			throw new Error("Step context was not restored after custom function call");
+		}
+
+		return result;
 	}
 }

--- a/test/e2e/http/crud.e2e.test.ts
+++ b/test/e2e/http/crud.e2e.test.ts
@@ -1431,9 +1431,11 @@ describe("CRUD routes (E2E)", () => {
 
 		expect(response.statusCode).toBe(201);
 		expect(response.json().name).toBe("custom-after-fn-generated-step-custom-StepGenerated");
-		expect(E2eFunctionSubscriber.events).toEqual(expect.arrayContaining(["function:before:custom.step.generated", "function:before:custom.step.generated:transaction", "function:before:create", "function:before:create:transaction", "function:after:create", "function:after:custom.step.generated"]));
+		expect(E2eFunctionSubscriber.events).toEqual(["function:before:custom.step.generated", "function:before:custom.step.generated:transaction", "function:priority:before:create", "function:before:create", "function:before:create:transaction", "function:priority:after:create", "function:after:create", "function:after:custom.step.generated"]);
 		expect(E2eFunctionSubscriber.events).not.toContain("function:before:step");
 		expect(E2eFunctionSubscriber.events).not.toContain("function:after:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before_error:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after_error:step");
 		expect((await service.repository.findOne({ where: { id: "custom-step-generated-1" } }))?.name).toBe("fn-generated-step-custom-StepGenerated");
 	});
 
@@ -1446,9 +1448,11 @@ describe("CRUD routes (E2E)", () => {
 
 		expect(response.statusCode).toBe(201);
 		expect(response.json().name).toBe("custom-after-custom-after-fn-custom-nested-step-custom-StepCustom");
-		expect(E2eFunctionSubscriber.events).toEqual(expect.arrayContaining(["function:before:custom.step.custom", "function:before:custom.step.custom:transaction", "function:before:custom.mandatory", "function:before:custom.mandatory:transaction", "function:before:create:transaction", "function:after:custom.mandatory", "function:after:custom.step.custom"]));
+		expect(E2eFunctionSubscriber.events).toEqual(["function:before:custom.step.custom", "function:before:custom.step.custom:transaction", "function:before:custom.mandatory", "function:before:custom.mandatory:transaction", "function:priority:before:create", "function:before:create", "function:before:create:transaction", "function:priority:after:create", "function:after:create", "function:after:custom.mandatory", "function:after:custom.step.custom"]);
 		expect(E2eFunctionSubscriber.events).not.toContain("function:before:step");
 		expect(E2eFunctionSubscriber.events).not.toContain("function:after:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before_error:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after_error:step");
 		expect((await service.repository.findOne({ where: { id: "custom-step-custom-1" } }))?.name).toBe("fn-custom-nested-step-custom-StepCustom");
 	});
 

--- a/test/e2e/http/crud.e2e.test.ts
+++ b/test/e2e/http/crud.e2e.test.ts
@@ -1389,6 +1389,69 @@ describe("CRUD routes (E2E)", () => {
 		expect(E2eFunctionSubscriber.events).not.toContain("function:before:custom.supports:transaction");
 	});
 
+	it("runs ApiFunctionStep inside an ApiFunctionCustom transaction through HTTP", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			payload: { count: 1, id: "custom-step-1", name: "Step", ownerId: E2E_OWNER_ID },
+			url: "/function/custom-step",
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().name).toBe("custom-after-step-custom-Step");
+		expect(E2eFunctionSubscriber.events).toEqual(expect.arrayContaining(["function:before:custom.step", "function:before:custom.step:transaction", "function:after:custom.step"]));
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before_error:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after_error:step");
+		expect((await service.repository.findOne({ where: { id: "custom-step-1" } }))?.name).toBe("step-custom-Step");
+	});
+
+	it("rolls back ApiFunctionStep work when the owning custom function fails", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			payload: { count: 1, id: "custom-step-rollback-1", name: "StepRollback", ownerId: E2E_OWNER_ID },
+			url: "/function/custom-step-rollback",
+		});
+
+		expect(response.statusCode).toBe(500);
+		expect(E2eFunctionSubscriber.events).toEqual(expect.arrayContaining(["function:before:custom.step.rollback", "function:before:custom.step.rollback:transaction", "function:after_error:custom.step.rollback"]));
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before_error:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after_error:step");
+		expect(await service.repository.findOne({ where: { id: "custom-step-rollback-1" } })).toBeNull();
+	});
+
+	it("allows ApiFunctionStep to call a generated function without exposing step subscriber metadata", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			payload: { count: 1, id: "custom-step-generated-1", name: "StepGenerated", ownerId: E2E_OWNER_ID },
+			url: "/function/custom-step-generated",
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().name).toBe("custom-after-fn-generated-step-custom-StepGenerated");
+		expect(E2eFunctionSubscriber.events).toEqual(expect.arrayContaining(["function:before:custom.step.generated", "function:before:custom.step.generated:transaction", "function:before:create", "function:before:create:transaction", "function:after:create", "function:after:custom.step.generated"]));
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after:step");
+		expect((await service.repository.findOne({ where: { id: "custom-step-generated-1" } }))?.name).toBe("fn-generated-step-custom-StepGenerated");
+	});
+
+	it("allows ApiFunctionStep to call a nested custom function without exposing step subscriber metadata", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			payload: { count: 1, id: "custom-step-custom-1", name: "StepCustom", ownerId: E2E_OWNER_ID },
+			url: "/function/custom-step-custom",
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json().name).toBe("custom-after-custom-after-fn-custom-nested-step-custom-StepCustom");
+		expect(E2eFunctionSubscriber.events).toEqual(expect.arrayContaining(["function:before:custom.step.custom", "function:before:custom.step.custom:transaction", "function:before:custom.mandatory", "function:before:custom.mandatory:transaction", "function:before:create:transaction", "function:after:custom.mandatory", "function:after:custom.step.custom"]));
+		expect(E2eFunctionSubscriber.events).not.toContain("function:before:step");
+		expect(E2eFunctionSubscriber.events).not.toContain("function:after:step");
+		expect((await service.repository.findOne({ where: { id: "custom-step-custom-1" } }))?.name).toBe("fn-custom-nested-step-custom-StepCustom");
+	});
+
 	it("runs built-in ApiFunction SUPPORTS mode without opening a transaction when none is active", async () => {
 		const response = await fastify.inject({
 			method: "POST",

--- a/test/e2e/public-api.e2e.test.ts
+++ b/test/e2e/public-api.e2e.test.ts
@@ -174,6 +174,10 @@ describe("public authorization API (E2E)", () => {
 				SUPPORTS?: unknown;
 			};
 		};
+		const builtCjsPackageEntryPath: string = "../../dist/cjs/index.js";
+		const builtCjsPackageEntry = (await import(builtCjsPackageEntryPath)) as {
+			ApiFunctionStep?: unknown;
+		};
 		const bigintStringDefaults = GetDefaultStringFormatProperties(EApiPropertyStringType.BIGINT_STRING, bigintStringOptions);
 		const resolvedPrincipal: IApiAuthorizationPrincipal = await Promise.resolve(
 			principalResolver.resolve({
@@ -193,6 +197,7 @@ describe("public authorization API (E2E)", () => {
 		expect(stepContext.getRepository(PublicApiUser)).toBe(stepRepository);
 		expect(stepContext.repository).toBe(stepRepository);
 		expect(typeof builtPackageEntry.ApiFunctionStep).toBe("function");
+		expect(typeof builtCjsPackageEntry.ApiFunctionStep).toBe("function");
 		expect(builtPackageEntry.EApiFunctionTransactionMode?.SUPPORTS).toBe(EApiFunctionTransactionMode.SUPPORTS);
 		expect(AUTHORIZATION_PRINCIPAL_RESOLVER_TOKEN).toBe("API_AUTHORIZATION_PRINCIPAL_RESOLVER");
 		expect(resolvedPrincipal.id).toBe("user-1");

--- a/test/e2e/public-api.e2e.test.ts
+++ b/test/e2e/public-api.e2e.test.ts
@@ -1,5 +1,7 @@
 import "reflect-metadata";
 
+import type { Repository } from "typeorm";
+
 import type {
 	IApiAuthorizationPrincipal,
 	IApiAuthorizationPrincipalResolver,
@@ -7,6 +9,9 @@ import type {
 	IApiAuthorizationRequestMetadata,
 	IApiAuthorizationRuleContext,
 	IApiAuthorizationScope,
+	IApiBaseEntity,
+	IApiFunctionStepContext,
+	IApiFunctionStepProperties,
 	IApiHookPermissionSource,
 	TApiAuthorizationPolicyBeforeCreateContext,
 	TApiAuthorizationPolicyBeforeCreateResult,
@@ -20,7 +25,7 @@ import type {
 	TApiRouteDiscriminatedDtoProperties,
 } from "../../src/index";
 
-import { ApiAuthorizationPolicy, ApiAuthorizationPolicyBase, AUTHORIZATION_PRINCIPAL_RESOLVER_TOKEN, EApiAuthorizationMode, EApiAuthorizationPrincipalType, EApiPropertyStringType, GetDefaultStringFormatProperties } from "../../src/index";
+import { ApiAuthorizationPolicy, ApiAuthorizationPolicyBase, ApiFunctionStep, AUTHORIZATION_PRINCIPAL_RESOLVER_TOKEN, EApiAuthorizationMode, EApiAuthorizationPrincipalType, EApiFunctionTransactionMode, EApiPropertyStringType, GetDefaultStringFormatProperties } from "../../src/index";
 import { describe, expect, it } from "vitest";
 
 class PublicApiUser {
@@ -32,6 +37,18 @@ class PublicApiUser {
 }
 
 class PublicApiEmailBodyDto {}
+
+class PublicApiStepService {
+	@ApiFunctionStep<PublicApiUser>({
+		entity: PublicApiUser,
+		transaction: {
+			mode: EApiFunctionTransactionMode.SUPPORTS,
+		},
+	})
+	public async step(): Promise<void> {
+		return await Promise.resolve();
+	}
+}
 
 class PublicApiPrincipalResolver implements IApiAuthorizationPrincipalResolver {
 	public resolve(user: unknown): IApiAuthorizationPrincipal {
@@ -141,6 +158,22 @@ describe("public authorization API (E2E)", () => {
 		const bigintStringOptions: TApiGetDefaultStringFormatPropertiesBigIntStringOptions = {
 			sign: "unsigned",
 		};
+		const stepProperties: IApiFunctionStepProperties<PublicApiUser> = {
+			entity: PublicApiUser,
+		};
+		const stepRepository = {} as Repository<PublicApiUser>;
+		const stepContext = {
+			eventManager: undefined,
+			getRepository: <T extends IApiBaseEntity>(_entity: new () => T): Repository<T> => stepRepository as unknown as Repository<T>,
+			repository: stepRepository,
+		} satisfies IApiFunctionStepContext<PublicApiUser>;
+		const builtPackageEntryPath: string = "../../dist/esm/index.js";
+		const builtPackageEntry = (await import(builtPackageEntryPath)) as {
+			ApiFunctionStep?: unknown;
+			EApiFunctionTransactionMode?: {
+				SUPPORTS?: unknown;
+			};
+		};
 		const bigintStringDefaults = GetDefaultStringFormatProperties(EApiPropertyStringType.BIGINT_STRING, bigintStringOptions);
 		const resolvedPrincipal: IApiAuthorizationPrincipal = await Promise.resolve(
 			principalResolver.resolve({
@@ -155,9 +188,16 @@ describe("public authorization API (E2E)", () => {
 		expect(requestMetadata.parameters).toEqual({ id: "user-1" });
 		expect(routeDiscriminatorConfig.discriminator.propertyName).toBe("channel");
 		expect(bigintStringDefaults.pattern).toBe(String.raw`/^(0|[1-9]\d{0,19})$/`);
+		expect(stepProperties.entity).toBe(PublicApiUser);
+		expect(stepContext.eventManager).toBeUndefined();
+		expect(stepContext.getRepository(PublicApiUser)).toBe(stepRepository);
+		expect(stepContext.repository).toBe(stepRepository);
+		expect(typeof builtPackageEntry.ApiFunctionStep).toBe("function");
+		expect(builtPackageEntry.EApiFunctionTransactionMode?.SUPPORTS).toBe(EApiFunctionTransactionMode.SUPPORTS);
 		expect(AUTHORIZATION_PRINCIPAL_RESOLVER_TOKEN).toBe("API_AUTHORIZATION_PRINCIPAL_RESOLVER");
 		expect(resolvedPrincipal.id).toBe("user-1");
 		expect(EApiAuthorizationMode.HOOKS).toBe("hooks");
 		expect(new PublicApiPolicy()).toBeInstanceOf(ApiAuthorizationPolicyBase);
+		expect(new PublicApiStepService()).toBeInstanceOf(PublicApiStepService);
 	});
 });

--- a/test/unit/class/api/function/custom/runtime.class.test.ts
+++ b/test/unit/class/api/function/custom/runtime.class.test.ts
@@ -11,6 +11,10 @@ class FunctionRuntimeEntity {
 	public id?: string;
 }
 
+class OtherFunctionRuntimeEntity {
+	public id?: string;
+}
+
 const createRepository = () => {
 	const transactionRepository = {} as Repository<FunctionRuntimeEntity>;
 	const transactionManager = {
@@ -53,6 +57,25 @@ describe("ApiFunctionCustomRuntime", () => {
 		expect(result).toBe(transactionManager);
 	});
 
+	it("does not expose function context storage to custom before subscribers when REQUIRED opens a transaction", async () => {
+		const { repository } = createRepository();
+		const beforeContextSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockImplementation(async () => ApiFunctionContextStorage.get<FunctionRuntimeEntity>());
+
+		await ApiFunctionCustomRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => "handler",
+			properties: {
+				action: "customAction",
+				entity: FunctionRuntimeEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.REQUIRED,
+		});
+
+		expect(beforeContextSpy).toHaveBeenCalled();
+		await expect(beforeContextSpy.mock.results[0]?.value).resolves.toBeUndefined();
+	});
+
 	it("joins an active transaction for SUPPORTS mode", async () => {
 		const { repository, transactionManager } = createRepository();
 		const originalMethod = vi.fn(async () => ApiFunctionContextStorage.get<FunctionRuntimeEntity>()?.eventManager);
@@ -80,6 +103,29 @@ describe("ApiFunctionCustomRuntime", () => {
 
 		expect(repository.manager.transaction).not.toHaveBeenCalled();
 		expect(result).toBe(transactionManager);
+	});
+
+	it("resolves non-transactional context repository from the configured custom entity", async () => {
+		const { repository } = createRepository();
+		const managerRepository = {} as Repository<OtherFunctionRuntimeEntity>;
+		vi.spyOn(repository.manager, "getRepository").mockReturnValue(managerRepository as never);
+		vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers").mockResolvedValue(undefined);
+
+		const result = await ApiFunctionCustomRuntime.execute<OtherFunctionRuntimeEntity>({
+			functionArguments: [],
+			originalMethod: async () => ApiFunctionContextStorage.get<OtherFunctionRuntimeEntity>()?.repository,
+			properties: {
+				action: "customAction",
+				entity: OtherFunctionRuntimeEntity,
+			},
+			target: {
+				repository: repository as unknown as Repository<OtherFunctionRuntimeEntity>,
+			},
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+
+		expect(repository.manager.getRepository).toHaveBeenCalledWith(OtherFunctionRuntimeEntity);
+		expect(result).toBe(managerRepository);
 	});
 
 	it("fails MANDATORY mode without an active transaction", async () => {

--- a/test/unit/class/api/function/step/runtime.class.test.ts
+++ b/test/unit/class/api/function/step/runtime.class.test.ts
@@ -395,6 +395,27 @@ describe("ApiFunctionStepRuntime", () => {
 		expect(errorSubscriberSpy).not.toHaveBeenCalled();
 	});
 
+	it("rethrows REQUIRED step failures from the opened transaction", async () => {
+		const { repository } = createRepository();
+		const error = new Error("required step failed");
+
+		await expect(
+			ApiFunctionStepRuntime.execute({
+				functionArguments: [],
+				originalMethod: async () => {
+					throw error;
+				},
+				properties: {
+					entity: FunctionStepEntity,
+				},
+				target: { repository },
+				transactionMode: EApiFunctionTransactionMode.REQUIRED,
+			}),
+		).rejects.toBe(error);
+
+		expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+	});
+
 	it("reuses an outer REQUIRED transaction for nested REQUIRED step calls", async () => {
 		const { repository, transactionManager } = createRepository();
 

--- a/test/unit/class/api/function/step/runtime.class.test.ts
+++ b/test/unit/class/api/function/step/runtime.class.test.ts
@@ -1,0 +1,487 @@
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { IApiFunctionContext, IApiFunctionStepContext } from "@interface/class/api/function";
+import type { EntityManager, Repository } from "typeorm";
+
+import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
+import { ApiFunctionStepRuntime } from "@class/api/function/step-runtime.class";
+import { ApiFunctionTransactionScope } from "@class/api/function/transaction-scope.class";
+import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";
+import { EApiFunctionTransactionMode } from "@enum/decorator/api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+class FunctionStepEntity {
+	public id?: string;
+}
+
+class OtherFunctionStepEntity {
+	public id?: string;
+}
+
+const createRepository = () => {
+	const transactionRepository = {} as Repository<FunctionStepEntity>;
+	const transactionManager = {
+		getRepository: vi.fn().mockReturnValue(transactionRepository),
+	} as unknown as EntityManager;
+	const managerRepository = {} as Repository<FunctionStepEntity>;
+	const repository = {
+		manager: {
+			getRepository: vi.fn().mockReturnValue(managerRepository),
+			transaction: vi.fn(async (callback: (entityManager: EntityManager) => Promise<unknown>) => await callback(transactionManager)),
+		},
+	} as unknown as Repository<FunctionStepEntity>;
+
+	return {
+		managerRepository,
+		repository,
+		transactionManager,
+		transactionRepository,
+	};
+};
+
+const createContext = (repository: Repository<FunctionStepEntity>, eventManager?: EntityManager): IApiFunctionContext<FunctionStepEntity> => ({
+	entity: FunctionStepEntity,
+	eventManager,
+	getRepository: <T extends IApiBaseEntity>() => repository as unknown as Repository<T>,
+	operations: {} as never,
+	repository,
+});
+
+describe("ApiFunctionStepRuntime", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("runs SUPPORTS outside a transaction without opening one", async () => {
+		const { managerRepository, repository } = createRepository();
+		const target = { repository };
+		const originalMethod = vi.fn(async function (this: typeof target, value: unknown) {
+			const context: IApiFunctionStepContext<FunctionStepEntity> | undefined = ApiFunctionContextStorage.getStep<FunctionStepEntity>();
+
+			return {
+				eventManager: context?.eventManager,
+				repository: context?.repository,
+				relatedRepository: context?.getRepository(FunctionStepEntity),
+				thisValue: this,
+				value: String(value),
+			};
+		});
+
+		const result = await ApiFunctionStepRuntime.execute({
+			functionArguments: ["supports"],
+			originalMethod,
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target,
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			eventManager: undefined,
+			relatedRepository: managerRepository,
+			repository: managerRepository,
+			thisValue: target,
+			value: "supports",
+		});
+	});
+
+	it("does not expose step context through the full function context storage accessor", async () => {
+		const { repository } = createRepository();
+
+		const result = await ApiFunctionStepRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => ({
+				functionContext: ApiFunctionContextStorage.get<FunctionStepEntity>(),
+				stepContext: ApiFunctionContextStorage.getStep<FunctionStepEntity>(),
+			}),
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+
+		expect(result).toEqual({
+			functionContext: undefined,
+			stepContext: {
+				eventManager: undefined,
+				getRepository: expect.any(Function),
+				repository: expect.any(Object),
+			},
+		});
+	});
+
+	it("joins an active transaction for SUPPORTS mode", async () => {
+		const { repository, transactionManager, transactionRepository } = createRepository();
+
+		const result = await ApiFunctionTransactionScope.runWithEntityManager(
+			transactionManager,
+			async () =>
+				await ApiFunctionStepRuntime.execute({
+					functionArguments: [],
+					originalMethod: async () => {
+						const context: IApiFunctionStepContext<FunctionStepEntity> | undefined = ApiFunctionContextStorage.getStep<FunctionStepEntity>();
+
+						return {
+							eventManager: context?.eventManager,
+							repository: context?.repository,
+						};
+					},
+					properties: {
+						entity: FunctionStepEntity,
+					},
+					target: { repository },
+					transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+				}),
+		);
+
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			eventManager: transactionManager,
+			repository: transactionRepository,
+		});
+	});
+
+	it("opens one transaction for REQUIRED mode outside an active transaction", async () => {
+		const { repository, transactionManager, transactionRepository } = createRepository();
+
+		const result = await ApiFunctionStepRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => {
+				const context: IApiFunctionStepContext<FunctionStepEntity> | undefined = ApiFunctionContextStorage.getStep<FunctionStepEntity>();
+
+				return {
+					eventManager: context?.eventManager,
+					repository: context?.repository,
+				};
+			},
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.REQUIRED,
+		});
+
+		expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({
+			eventManager: transactionManager,
+			repository: transactionRepository,
+		});
+	});
+
+	it("reuses an active transaction for REQUIRED mode", async () => {
+		const { repository, transactionManager, transactionRepository } = createRepository();
+
+		const result = await ApiFunctionTransactionScope.runWithEntityManager(
+			transactionManager,
+			async () =>
+				await ApiFunctionStepRuntime.execute({
+					functionArguments: [],
+					originalMethod: async () => ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.eventManager,
+					properties: {
+						entity: FunctionStepEntity,
+					},
+					target: { repository },
+					transactionMode: EApiFunctionTransactionMode.REQUIRED,
+				}),
+		);
+
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
+		expect(transactionManager.getRepository).toHaveBeenCalledWith(FunctionStepEntity);
+		expect(result).toBe(transactionManager);
+		expect(ApiFunctionContextStorage.get()).toBeUndefined();
+		expect(transactionRepository).toBeDefined();
+	});
+
+	it("runs NONE mode outside a transaction without opening one", async () => {
+		const { managerRepository, repository } = createRepository();
+
+		const result = await ApiFunctionStepRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => {
+				const context: IApiFunctionStepContext<FunctionStepEntity> | undefined = ApiFunctionContextStorage.getStep<FunctionStepEntity>();
+
+				return {
+					eventManager: context?.eventManager,
+					relatedRepository: context?.getRepository(FunctionStepEntity),
+					repository: context?.repository,
+				};
+			},
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.NONE,
+		});
+
+		expect(repository.manager.transaction).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			eventManager: undefined,
+			relatedRepository: managerRepository,
+			repository: managerRepository,
+		});
+	});
+
+	it("resolves non-transactional context repository from the configured step entity", async () => {
+		const { managerRepository, repository } = createRepository();
+
+		const result = await ApiFunctionStepRuntime.execute<OtherFunctionStepEntity>({
+			functionArguments: [],
+			originalMethod: async () => ApiFunctionContextStorage.getStep<OtherFunctionStepEntity>()?.repository,
+			properties: {
+				entity: OtherFunctionStepEntity,
+			},
+			target: {
+				repository: repository as unknown as Repository<OtherFunctionStepEntity>,
+			},
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+
+		expect(repository.manager.getRepository).toHaveBeenCalledWith(OtherFunctionStepEntity);
+		expect(result).toBe(managerRepository);
+	});
+
+	it("resolves getRepository helper from the requested entity inside an active transaction", async () => {
+		const { repository, transactionManager } = createRepository();
+
+		const result = await ApiFunctionTransactionScope.runWithEntityManager(
+			transactionManager,
+			async () =>
+				await ApiFunctionStepRuntime.execute({
+					functionArguments: [],
+					originalMethod: async () => ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.getRepository(OtherFunctionStepEntity),
+					properties: {
+						entity: FunctionStepEntity,
+					},
+					target: { repository },
+					transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+				}),
+		);
+
+		expect(transactionManager.getRepository).toHaveBeenCalledWith(OtherFunctionStepEntity);
+		expect(result).toBeDefined();
+	});
+
+	it("fails MANDATORY mode outside an active transaction", async () => {
+		const { repository } = createRepository();
+		const originalMethod = vi.fn(async () => undefined);
+
+		await expect(
+			ApiFunctionStepRuntime.execute({
+				functionArguments: [],
+				originalMethod,
+				properties: {
+					entity: FunctionStepEntity,
+				},
+				target: { repository },
+				transactionMode: EApiFunctionTransactionMode.MANDATORY,
+			}),
+		).rejects.toThrow("ApiFunctionStep transaction mode MANDATORY requires an active transaction");
+		expect(originalMethod).not.toHaveBeenCalled();
+	});
+
+	it("fails NONE mode inside an active transaction", async () => {
+		const { repository, transactionManager } = createRepository();
+		const originalMethod = vi.fn(async () => undefined);
+		const subscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers");
+		const errorSubscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers");
+
+		await expect(
+			ApiFunctionContextStorage.run(
+				createContext(repository, transactionManager),
+				async () =>
+					await ApiFunctionStepRuntime.execute({
+						functionArguments: [],
+						originalMethod,
+						properties: {
+							entity: FunctionStepEntity,
+						},
+						target: { repository },
+						transactionMode: EApiFunctionTransactionMode.NONE,
+					}),
+			),
+		).rejects.toThrow("ApiFunctionStep transaction mode NONE cannot run inside an active transaction");
+		expect(originalMethod).not.toHaveBeenCalled();
+		expect(subscriberSpy).not.toHaveBeenCalled();
+		expect(errorSubscriberSpy).not.toHaveBeenCalled();
+	});
+
+	it("fails REQUIRED mode outside a transaction when the service repository is unavailable", async () => {
+		const originalMethod = vi.fn(async () => undefined);
+
+		await expect(
+			ApiFunctionStepRuntime.execute({
+				functionArguments: [],
+				originalMethod,
+				properties: {
+					entity: FunctionStepEntity,
+				},
+				target: {},
+				transactionMode: EApiFunctionTransactionMode.REQUIRED,
+			}),
+		).rejects.toThrow("Repository is not available in this context");
+
+		expect(originalMethod).not.toHaveBeenCalled();
+	});
+
+	it("fails before running the step body when non-transactional context repository resolution is unavailable", async () => {
+		const originalMethod = vi.fn(async () => undefined);
+
+		await expect(
+			ApiFunctionStepRuntime.execute({
+				functionArguments: [],
+				originalMethod,
+				properties: {
+					entity: FunctionStepEntity,
+				},
+				target: {},
+				transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+			}),
+		).rejects.toThrow("Repository is not available in this context");
+
+		expect(originalMethod).not.toHaveBeenCalled();
+	});
+
+	it("rethrows step failures and restores the outer context", async () => {
+		const { repository, transactionManager } = createRepository();
+		const outerContext: IApiFunctionContext<FunctionStepEntity> = createContext(repository, transactionManager);
+		const error = new Error("step failed");
+		const subscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers");
+		const errorSubscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers");
+
+		await ApiFunctionContextStorage.run(outerContext, async () => {
+			await expect(
+				ApiFunctionStepRuntime.execute({
+					functionArguments: [],
+					originalMethod: async () => {
+						throw error;
+					},
+					properties: {
+						entity: FunctionStepEntity,
+					},
+					target: { repository },
+					transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+				}),
+			).rejects.toBe(error);
+			expect(ApiFunctionContextStorage.get()).toBe(outerContext);
+		});
+		expect(subscriberSpy).not.toHaveBeenCalled();
+		expect(errorSubscriberSpy).not.toHaveBeenCalled();
+	});
+
+	it("reuses an outer REQUIRED transaction for nested REQUIRED step calls", async () => {
+		const { repository, transactionManager } = createRepository();
+
+		const result = await ApiFunctionStepRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => {
+				const outerEventManager: EntityManager | undefined = ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.eventManager;
+				const innerEventManager = await ApiFunctionStepRuntime.execute({
+					functionArguments: [],
+					originalMethod: async () => ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.eventManager,
+					properties: {
+						entity: FunctionStepEntity,
+					},
+					target: { repository },
+					transactionMode: EApiFunctionTransactionMode.REQUIRED,
+				});
+
+				return {
+					innerEventManager,
+					outerEventManager,
+				};
+			},
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.REQUIRED,
+		});
+
+		expect(repository.manager.transaction).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({
+			innerEventManager: transactionManager,
+			outerEventManager: transactionManager,
+		});
+	});
+
+	it("reuses the same context for nested step calls", async () => {
+		const { repository, transactionManager } = createRepository();
+
+		const result = await ApiFunctionTransactionScope.runWithEntityManager(
+			transactionManager,
+			async () =>
+				await ApiFunctionStepRuntime.execute({
+					functionArguments: [],
+					originalMethod: async () => {
+						const outerEventManager: EntityManager | undefined = ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.eventManager;
+						const innerEventManager = await ApiFunctionStepRuntime.execute({
+							functionArguments: [],
+							originalMethod: async () => ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.eventManager,
+							properties: {
+								entity: FunctionStepEntity,
+							},
+							target: { repository },
+							transactionMode: EApiFunctionTransactionMode.MANDATORY,
+						});
+
+						return {
+							innerEventManager,
+							outerEventManager,
+						};
+					},
+					properties: {
+						entity: FunctionStepEntity,
+					},
+					target: { repository },
+					transactionMode: EApiFunctionTransactionMode.MANDATORY,
+				}),
+		);
+
+		expect(result).toEqual({
+			innerEventManager: transactionManager,
+			outerEventManager: transactionManager,
+		});
+	});
+
+	it("does not execute function subscribers for steps", async () => {
+		const { repository } = createRepository();
+		const subscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers");
+		const errorSubscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers");
+
+		await ApiFunctionStepRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => "ok",
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+
+		expect(subscriberSpy).not.toHaveBeenCalled();
+		expect(errorSubscriberSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not execute function subscribers for MANDATORY preflight failures", async () => {
+		const { repository } = createRepository();
+		const subscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers");
+		const errorSubscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers");
+
+		await expect(
+			ApiFunctionStepRuntime.execute({
+				functionArguments: [],
+				originalMethod: async () => "ok",
+				properties: {
+					entity: FunctionStepEntity,
+				},
+				target: { repository },
+				transactionMode: EApiFunctionTransactionMode.MANDATORY,
+			}),
+		).rejects.toThrow("ApiFunctionStep transaction mode MANDATORY requires an active transaction");
+
+		expect(subscriberSpy).not.toHaveBeenCalled();
+		expect(errorSubscriberSpy).not.toHaveBeenCalled();
+	});
+});

--- a/test/unit/class/api/function/step/runtime.class.test.ts
+++ b/test/unit/class/api/function/step/runtime.class.test.ts
@@ -242,6 +242,23 @@ describe("ApiFunctionStepRuntime", () => {
 		expect(result).toBe(managerRepository);
 	});
 
+	it("resolves non-transactional getRepository helper from the requested entity", async () => {
+		const { managerRepository, repository } = createRepository();
+
+		const result = await ApiFunctionStepRuntime.execute({
+			functionArguments: [],
+			originalMethod: async () => ApiFunctionContextStorage.getStep<FunctionStepEntity>()?.getRepository(OtherFunctionStepEntity),
+			properties: {
+				entity: FunctionStepEntity,
+			},
+			target: { repository },
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+
+		expect(repository.manager.getRepository).toHaveBeenCalledWith(OtherFunctionStepEntity);
+		expect(result).toBe(managerRepository);
+	});
+
 	it("resolves getRepository helper from the requested entity inside an active transaction", async () => {
 		const { repository, transactionManager } = createRepository();
 
@@ -309,6 +326,8 @@ describe("ApiFunctionStepRuntime", () => {
 
 	it("fails REQUIRED mode outside a transaction when the service repository is unavailable", async () => {
 		const originalMethod = vi.fn(async () => undefined);
+		const subscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers");
+		const errorSubscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers");
 
 		await expect(
 			ApiFunctionStepRuntime.execute({
@@ -323,10 +342,14 @@ describe("ApiFunctionStepRuntime", () => {
 		).rejects.toThrow("Repository is not available in this context");
 
 		expect(originalMethod).not.toHaveBeenCalled();
+		expect(subscriberSpy).not.toHaveBeenCalled();
+		expect(errorSubscriberSpy).not.toHaveBeenCalled();
 	});
 
 	it("fails before running the step body when non-transactional context repository resolution is unavailable", async () => {
 		const originalMethod = vi.fn(async () => undefined);
+		const subscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionSubscribers");
+		const errorSubscriberSpy = vi.spyOn(ApiSubscriberExecutor, "executeFunctionErrorSubscribers");
 
 		await expect(
 			ApiFunctionStepRuntime.execute({
@@ -341,6 +364,8 @@ describe("ApiFunctionStepRuntime", () => {
 		).rejects.toThrow("Repository is not available in this context");
 
 		expect(originalMethod).not.toHaveBeenCalled();
+		expect(subscriberSpy).not.toHaveBeenCalled();
+		expect(errorSubscriberSpy).not.toHaveBeenCalled();
 	});
 
 	it("rethrows step failures and restores the outer context", async () => {

--- a/test/unit/class/api/subscriber/executor.class.test.ts
+++ b/test/unit/class/api/subscriber/executor.class.test.ts
@@ -1,6 +1,9 @@
 import type { IApiSubscriberFunction } from "@interface/class/api/subscriber/function.interface";
 import type { IApiSubscriberRoute } from "@interface/class/api/subscriber/route.interface";
+import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
+import type { EntityManager, Repository } from "typeorm";
 
+import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
 import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";
 import { apiSubscriberRegistry } from "@class/api/subscriber/registry.class";
 import { CONTROLLER_API_DECORATOR_CONSTANT } from "@constant/decorator/api/controller.constant";
@@ -344,6 +347,56 @@ describe("ApiSubscriberExecutor", () => {
 
 		expect(functionSubscriber.onBeforeGet).toHaveBeenCalledTimes(1);
 		expect(result).toEqual({ id: "original" });
+	});
+
+	it("masks outer step context while executing function subscribers", async () => {
+		class FunctionEntity {
+			public id?: string;
+		}
+
+		class TestService {}
+
+		Reflect.defineMetadata(SERVICE_API_DECORATOR_CONSTANT.OBSERVABLE_METADATA_KEY, true, TestService);
+
+		const eventManager = {} as EntityManager;
+		const repository = {} as Repository<FunctionEntity>;
+		const observedStorage = vi.fn();
+		const functionSubscriber: IApiSubscriberFunction<FunctionEntity> = {
+			onBeforeGet: vi.fn(async () => {
+				observedStorage({
+					eventManager: ApiFunctionContextStorage.getEventManager(),
+					functionContext: ApiFunctionContextStorage.get<FunctionEntity>(),
+					stepContext: ApiFunctionContextStorage.getStep<FunctionEntity>(),
+				});
+
+				return undefined;
+			}),
+		};
+		const stepContext = {
+			eventManager,
+			getRepository: <T extends IApiBaseEntity>() => repository as unknown as Repository<T>,
+			repository,
+		};
+
+		apiSubscriberRegistry.registerFunctionSubscriber({ entity: FunctionEntity, priority: 1 }, functionSubscriber);
+
+		await ApiFunctionContextStorage.runStep(stepContext, async () => {
+			await ApiSubscriberExecutor.executeFunctionSubscribers(TestService, new FunctionEntity(), EApiFunctionType.GET, EApiSubscriberOnType.BEFORE, {
+				DATA: {} as never,
+				ENTITY: new FunctionEntity(),
+				FUNCTION_TYPE: EApiFunctionType.GET,
+				result: { id: "original" },
+			});
+
+			expect(ApiFunctionContextStorage.getStep<FunctionEntity>()).toBe(stepContext);
+		});
+
+		expect(functionSubscriber.onBeforeGet).toHaveBeenCalledTimes(1);
+		expect(observedStorage).toHaveBeenCalledWith({
+			eventManager,
+			functionContext: undefined,
+			stepContext: undefined,
+		});
 	});
 
 	it("skips function subscribers when service is not observable", async () => {

--- a/test/unit/decorator/api/function/step.decorator.test.ts
+++ b/test/unit/decorator/api/function/step.decorator.test.ts
@@ -10,7 +10,7 @@ import { METHOD_API_DECORATOR_CONSTANT } from "@constant/decorator/api";
 import { SUBSCRIBER_API_DECORATOR_CONSTANT } from "@constant/decorator/api/subscriber.constant";
 import { ApiFunctionStep } from "@decorator/api/function/step.decorator";
 import { EApiFunctionTransactionMode } from "@enum/decorator/api";
-import { METHOD_METADATA, PATH_METADATA } from "@nestjs/common/constants.js";
+import { GUARDS_METADATA, METHOD_METADATA, PATH_METADATA } from "@nestjs/common/constants.js";
 import { DECORATORS } from "@nestjs/swagger/dist/constants.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -118,6 +118,8 @@ describe("ApiFunctionStep", () => {
 		expect(Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_RUNTIME_PROPERTIES_METADATA_KEY, StepDecoratorService.prototype.publicStep)).toBeUndefined();
 		expect(Reflect.getMetadata(SUBSCRIBER_API_DECORATOR_CONSTANT.FUNCTION_METADATA_KEY, StepDecoratorService)).toBeUndefined();
 		expect(Reflect.getMetadata(DECORATORS.API_OPERATION, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+		expect(Reflect.getMetadata(DECORATORS.API_SECURITY, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+		expect(Reflect.getMetadata(GUARDS_METADATA, StepDecoratorService.prototype.publicStep)).toBeUndefined();
 	});
 
 	it("supports decorated private methods invoked by public service methods", async () => {

--- a/test/unit/decorator/api/function/step.decorator.test.ts
+++ b/test/unit/decorator/api/function/step.decorator.test.ts
@@ -1,0 +1,157 @@
+import "reflect-metadata";
+
+import type { IApiFunctionStepContext } from "@interface/class/api/function";
+import type { EntityManager, Repository } from "typeorm";
+
+import { ApiFunctionStepRuntime } from "@class/api/function/step-runtime.class";
+import { ApiFunctionTransactionScope } from "@class/api/function/transaction-scope.class";
+import { ApiServiceBase } from "@class/api/service-base.class";
+import { METHOD_API_DECORATOR_CONSTANT } from "@constant/decorator/api";
+import { SUBSCRIBER_API_DECORATOR_CONSTANT } from "@constant/decorator/api/subscriber.constant";
+import { ApiFunctionStep } from "@decorator/api/function/step.decorator";
+import { EApiFunctionTransactionMode } from "@enum/decorator/api";
+import { METHOD_METADATA, PATH_METADATA } from "@nestjs/common/constants.js";
+import { DECORATORS } from "@nestjs/swagger/dist/constants.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+class StepDecoratorEntity {
+	public id?: string;
+}
+
+class StepDecoratorService extends ApiServiceBase<StepDecoratorEntity> {
+	public constructor(public readonly repository: Repository<StepDecoratorEntity>) {
+		super();
+	}
+
+	@ApiFunctionStep({ entity: StepDecoratorEntity })
+	public async publicStep(value: string): Promise<string> {
+		return `public:${value}`;
+	}
+
+	public async callPrivateStep(value: string): Promise<IApiFunctionStepContext<StepDecoratorEntity>> {
+		return await this.privateStep(value);
+	}
+
+	public async callProtectedStep(value: string): Promise<IApiFunctionStepContext<StepDecoratorEntity>> {
+		return await this.protectedStep(value);
+	}
+
+	public readStepContextOutsideStep(): IApiFunctionStepContext<StepDecoratorEntity> {
+		return this.getApiFunctionStepContext<StepDecoratorEntity>();
+	}
+
+	@ApiFunctionStep({
+		entity: StepDecoratorEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.MANDATORY,
+		},
+	})
+	private async privateStep(_value: string): Promise<IApiFunctionStepContext<StepDecoratorEntity>> {
+		return this.getApiFunctionStepContext<StepDecoratorEntity>();
+	}
+
+	@ApiFunctionStep({
+		entity: StepDecoratorEntity,
+		transaction: {
+			mode: EApiFunctionTransactionMode.MANDATORY,
+		},
+	})
+	protected async protectedStep(_value: string): Promise<IApiFunctionStepContext<StepDecoratorEntity>> {
+		return this.getApiFunctionStepContext<StepDecoratorEntity>();
+	}
+
+	@ApiFunctionStep({
+		entity: StepDecoratorEntity,
+	})
+	public async readFullFunctionContextFromStep(): Promise<unknown> {
+		return this.getApiFunctionContext<StepDecoratorEntity>();
+	}
+}
+
+const createRepository = () => {
+	const transactionRepository = {} as Repository<StepDecoratorEntity>;
+	const transactionManager = {
+		getRepository: vi.fn().mockReturnValue(transactionRepository),
+	} as unknown as EntityManager;
+	const repository = {
+		manager: {
+			getRepository: vi.fn().mockReturnValue({} as Repository<StepDecoratorEntity>),
+			transaction: vi.fn(async (callback: (entityManager: EntityManager) => Promise<unknown>) => await callback(transactionManager)),
+		},
+	} as unknown as Repository<StepDecoratorEntity>;
+
+	return {
+		repository,
+		transactionManager,
+		transactionRepository,
+	};
+};
+
+describe("ApiFunctionStep", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("wraps methods and delegates to the step runtime with SUPPORTS by default", async () => {
+		const { repository } = createRepository();
+		const service = new StepDecoratorService(repository);
+		const executeSpy = vi.spyOn(ApiFunctionStepRuntime, "execute").mockResolvedValue("runtime-result");
+
+		const result = await service.publicStep("input");
+
+		expect(result).toBe("runtime-result");
+		expect(executeSpy).toHaveBeenCalledWith({
+			functionArguments: ["input"],
+			originalMethod: expect.any(Function),
+			properties: {
+				entity: StepDecoratorEntity,
+			},
+			target: service,
+			transactionMode: EApiFunctionTransactionMode.SUPPORTS,
+		});
+	});
+
+	it("does not attach route, subscriber, or Swagger metadata", () => {
+		expect(Reflect.getMetadata(PATH_METADATA, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+		expect(Reflect.getMetadata(METHOD_METADATA, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+		expect(Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+		expect(Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_RUNTIME_PROPERTIES_METADATA_KEY, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+		expect(Reflect.getMetadata(SUBSCRIBER_API_DECORATOR_CONSTANT.FUNCTION_METADATA_KEY, StepDecoratorService)).toBeUndefined();
+		expect(Reflect.getMetadata(DECORATORS.API_OPERATION, StepDecoratorService.prototype.publicStep)).toBeUndefined();
+	});
+
+	it("supports decorated private methods invoked by public service methods", async () => {
+		const { repository, transactionManager, transactionRepository } = createRepository();
+		const service = new StepDecoratorService(repository);
+
+		const context = await ApiFunctionTransactionScope.runWithEntityManager(transactionManager, async () => await service.callPrivateStep("private"));
+
+		expect(context.eventManager).toBe(transactionManager);
+		expect(context.repository).toBe(transactionRepository);
+		expect(context).not.toHaveProperty("operations");
+	});
+
+	it("supports decorated protected methods invoked by public service methods", async () => {
+		const { repository, transactionManager, transactionRepository } = createRepository();
+		const service = new StepDecoratorService(repository);
+
+		const context = await ApiFunctionTransactionScope.runWithEntityManager(transactionManager, async () => await service.callProtectedStep("protected"));
+
+		expect(context.eventManager).toBe(transactionManager);
+		expect(context.repository).toBe(transactionRepository);
+	});
+
+	it("rejects full function context access from step bodies", async () => {
+		const { repository } = createRepository();
+		const service = new StepDecoratorService(repository);
+
+		await expect(service.readFullFunctionContextFromStep()).rejects.toThrow("Api function context is not available inside a decorated ApiFunctionStep execution");
+	});
+
+	it("rejects step context access outside step bodies", () => {
+		const { repository } = createRepository();
+		const service = new StepDecoratorService(repository);
+
+		expect(() => service.readStepContextOutsideStep()).toThrow("Api function step context is not available outside a decorated ApiFunctionStep execution");
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `@ApiFunctionStep` as an internal transaction-aware helper primitive without subscriber, route, Swagger, or authorization metadata.
- Splits function and step context storage so steps expose only the narrow step context while still propagating transaction managers.
- Covers transaction modes, nested generated/custom calls, rollback, metadata absence, public API exports, and docs/AI guidance.

## Test plan
- `npm run lint:types`
- `npm run lint`
- `npm run test:unit`
- `npm run test:e2e`
- `git diff --check`

## Note
- This is a stacked PR from `feature/request-relation-include`, so the diff against `dev` includes inherited feature-branch commits.