### PR TITLE
feat(api): document response headers and grouped security

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,19 @@ import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
+				},
+			},
+			response: {
+				headers: {
+					"X-Request-Id": {
+						description: "Request correlation id.",
+						schema: { type: "string" },
+					},
 				},
 			},
 		},
@@ -206,7 +218,11 @@ import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 		},
@@ -215,7 +231,11 @@ import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 		},
@@ -228,6 +248,10 @@ export class UserController {
 	constructor(public service: UserService) {}
 }
 ```
+
+Use `response.headers` for Swagger/OpenAPI response header documentation only. Authentication `securityRequirements` map to OpenAPI route requirements: one object means all listed schemes are required together, while multiple objects are alternatives. The scheme names must match the names registered in your app-owned `DocumentBuilder` configuration.
+
+Top-level `authentication.bearerStrategies` and `authentication.securityStrategies` are not supported; put scheme names inside `authentication.securityRequirements`.
 
 ## Advanced Usage
 
@@ -1152,7 +1176,19 @@ import { AppModule } from "./app.module";
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
 
-	const config = new DocumentBuilder().setTitle("Your API").setDescription("API description").setVersion("1.0").addBearerAuth().build();
+	const config = new DocumentBuilder()
+		.setTitle("Your API")
+		.setDescription("API description")
+		.setVersion("1.0")
+		.addBearerAuth(
+			{
+				bearerFormat: "JWT",
+				scheme: "bearer",
+				type: "http",
+			},
+			"jwt",
+		)
+		.build();
 
 	const document = SwaggerModule.createDocument(app, config);
 	SwaggerModule.setup("api", app, document);

--- a/ai/crud-automator/SKILL.md
+++ b/ai/crud-automator/SKILL.md
@@ -29,8 +29,10 @@ Use local source as the contract:
 - Route controls live under `generation`: `generation.isEnabled`, `generation.shouldWriteToController`, and `generation.decorators`.
 - Route security lives under `security.authentication` and `security.authorization`.
 - `authentication.type` is the principal category (`USER`, `ADMIN`, `ACCOUNT`, `MERCHANT`, or project string), not the bearer/security scheme.
+- Route-level Swagger security schemes use `authentication.securityRequirements`; one object is an AND group and multiple objects are OR alternatives.
 - Request config is target keyed with `EApiControllerRequestTarget.BODY`, `PARAMETERS`, and `QUERY`.
 - Response config is target keyed with `EApiControllerResponseTarget.RESPONSE`.
+- OpenAPI response headers live directly under `response.headers`, not under `EApiControllerResponseTarget.RESPONSE`.
 - `autoDto` is validators-only. Field exposure, requiredness, filters, guards, and response visibility belong to `ApiPropertyDescribe({ properties })`.
 - Manual `dto` and `autoDto` route branches are mutually exclusive.
 - `ApiPropertyDescribe` object metadata uses `dataType`; manual `ApiPropertyObject` uses `type`.

--- a/ai/crud-automator/reference.md
+++ b/ai/crud-automator/reference.md
@@ -37,7 +37,11 @@ routes: {
 			authentication: {
 				type: EApiAuthenticationType.USER,
 				guard: JwtAuthGuard,
-				bearerStrategies: ["jwt"],
+				securityRequirements: [
+					{
+						bearerStrategies: ["jwt"],
+					},
+				],
 			},
 			authorization: {
 				mode: EApiAuthorizationMode.HOOKS,
@@ -50,6 +54,12 @@ routes: {
 			},
 		},
 		response: {
+			headers: {
+				"X-Request-Id": {
+					description: "Request correlation id.",
+					schema: { type: "string" },
+				},
+			},
 			[EApiControllerResponseTarget.RESPONSE]: {
 				transformers: [],
 			},
@@ -73,7 +83,7 @@ routes: {
 }
 ```
 
-Do not use old flat fields such as route-level `isEnabled`, `authentication`, `authorization`, `request.transformers`, `response.transformers`, `request.relations`, or `response.relations`.
+Do not use old flat fields such as route-level `isEnabled`, `authentication`, `authorization`, `request.transformers`, `response.transformers`, `request.relations`, or `response.relations`. Do not use removed top-level `authentication.bearerStrategies` or `authentication.securityStrategies`; use `authentication.securityRequirements` groups instead.
 
 ## DTO Rules
 

--- a/docs/api-reference/decorators/api-controller/api-controller/page.mdx
+++ b/docs/api-reference/decorators/api-controller/api-controller/page.mdx
@@ -47,7 +47,11 @@ Routes also accept:
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 		},
@@ -56,6 +60,14 @@ Routes also accept:
 				summary: "List users",
 				description: "Returns a filtered and paginated list of users",
 				operationId: "listUsers",
+			},
+			response: {
+				headers: {
+					"X-Request-Id": {
+						description: "Request correlation id.",
+						schema: { type: "string" },
+					},
+				},
 			},
 			autoDto: {
 				[EApiDtoType.QUERY]: {

--- a/docs/api-reference/decorators/api-method/api-method/page.mdx
+++ b/docs/api-reference/decorators/api-method/api-method/page.mdx
@@ -84,13 +84,23 @@ export class UserController {
 			response: {
 				status: HttpStatus.OK,
 				type: ActivateUserResponseDto,
+				headers: {
+					"X-Request-Id": {
+						description: "Request correlation id.",
+						schema: { type: "string" },
+					},
+				},
 				errors: { hasBadRequest: true, hasUnauthorized: true, hasForbidden: true },
 			},
 			security: {
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["access-token"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["access-token"],
+						},
+					],
 				},
 				authorization: {
 					mode: EApiAuthorizationMode.HOOKS,

--- a/docs/api-reference/decorators/api-method/api-route-custom/page.mdx
+++ b/docs/api-reference/decorators/api-method/api-route-custom/page.mdx
@@ -16,7 +16,7 @@ Use it when a controller method is not standard CRUD but should still behave lik
 
 `@ApiRouteCustom` separates route metadata from runtime properties:
 
-- Metadata fields (`resource`, `route`, `documentation`, `security`, `throttling`, and response `status`, `type`, `errors`, `serialization`) are stored as `IApiRouteMetadata`.
+- Metadata fields (`resource`, `route`, `documentation`, `security`, `throttling`, and response `status`, `type`, `headers`, `errors`, `serialization`) are stored as `IApiRouteMetadata`.
 - Runtime fields (`request`, target-first response transformers, `relations`, `dto`, and `autoDto`) are stored as `IApiRouteRuntimeProperties`.
 - Response target keys such as `[EApiControllerResponseTarget.RESPONSE]` belong only to runtime properties, not method metadata.
 
@@ -38,6 +38,11 @@ Custom routes can use the same target-first request and response configuration a
 		authentication: {
 			type: EApiAuthenticationType.USER,
 			guard: JwtAuthGuard,
+			securityRequirements: [
+				{
+					bearerStrategies: ["jwt"],
+				},
+			],
 		},
 		authorization: {
 			mode: EApiAuthorizationMode.HOOKS,
@@ -56,6 +61,12 @@ Custom routes can use the same target-first request and response configuration a
 		},
 	},
 	response: {
+		headers: {
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: { type: "string" },
+			},
+		},
 		status: HttpStatus.OK,
 		type: PublishPostResponseDto,
 		serialization: { isEnabled: true },

--- a/docs/api-reference/interfaces/page.mdx
+++ b/docs/api-reference/interfaces/page.mdx
@@ -77,12 +77,41 @@ Authentication configuration for routes.
 
 ```typescript
 interface IApiControllerPropertiesRouteAuthentication {
-	bearerStrategies?: Array<string>;
 	guard: Type<IAuthGuard>;
-	securityStrategies?: Array<string>;
+	securityRequirements?: Array<IApiRouteSecurityRequirement>;
 	type: EApiAuthenticationType | string;
 }
 ```
+
+Use `securityRequirements` for route-level Swagger security. Top-level `bearerStrategies` and `securityStrategies` are not part of the current authentication config.
+
+### IApiRouteSecurityRequirement
+
+One OpenAPI route security requirement group.
+
+```typescript
+interface IApiRouteSecurityRequirement {
+	bearerStrategies?: Array<string>;
+	cookieStrategies?: Array<string>;
+	securityStrategies?: Array<string>;
+}
+```
+
+Each `securityRequirements` item is one OpenAPI AND group. Multiple items are OR alternatives. Global scheme declarations remain application-owned.
+
+### IApiControllerPropertiesRouteBaseResponse\<E, R\>
+
+Generated route response configuration.
+
+```typescript
+interface IApiControllerPropertiesRouteBaseResponse<E, R extends EApiRouteType> {
+	[EApiControllerResponseTarget.RESPONSE]?: R extends EApiRouteType.DELETE ? never : IApiControllerPropertiesRouteBaseResponseTarget<E>;
+	headers?: HeadersObject;
+	serialization?: IApiRouteResponseSerializationProperties;
+}
+```
+
+`headers` is Swagger/OpenAPI metadata for the success response. Runtime response body transformers remain under `[EApiControllerResponseTarget.RESPONSE]`.
 
 ## Subscriber Interfaces
 

--- a/docs/core-concepts/controllers/page.mdx
+++ b/docs/core-concepts/controllers/page.mdx
@@ -120,7 +120,11 @@ import { EApiAuthenticationType } from "@elsikora/nestjs-crud-automator";
         authentication: {
           type: EApiAuthenticationType.USER,
           guard: JwtAuthGuard,
-          bearerStrategies: ["jwt"],
+          securityRequirements: [
+            {
+              bearerStrategies: ["jwt"],
+            },
+          ],
         },
       },
     },
@@ -129,7 +133,11 @@ import { EApiAuthenticationType } from "@elsikora/nestjs-crud-automator";
         authentication: {
           type: EApiAuthenticationType.USER,
           guard: JwtAuthGuard,
-          bearerStrategies: ["jwt"],
+          securityRequirements: [
+            {
+              bearerStrategies: ["jwt"],
+            },
+          ],
         },
       },
     },
@@ -138,7 +146,11 @@ import { EApiAuthenticationType } from "@elsikora/nestjs-crud-automator";
         authentication: {
           type: EApiAuthenticationType.USER,
           guard: JwtAuthGuard,
-          bearerStrategies: ["jwt"],
+          securityRequirements: [
+            {
+              bearerStrategies: ["jwt"],
+            },
+          ],
         },
       },
     },

--- a/docs/core-concepts/decorators/page.mdx
+++ b/docs/core-concepts/decorators/page.mdx
@@ -200,7 +200,11 @@ Decorators can be combined to create sophisticated configurations:
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 			autoDto: {

--- a/docs/getting-started/page.mdx
+++ b/docs/getting-started/page.mdx
@@ -229,7 +229,19 @@ import { AppModule } from "./app.module";
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
 
-	const config = new DocumentBuilder().setTitle("Your API").setDescription("API description").setVersion("1.0").addBearerAuth().build();
+	const config = new DocumentBuilder()
+		.setTitle("Your API")
+		.setDescription("API description")
+		.setVersion("1.0")
+		.addBearerAuth(
+			{
+				bearerFormat: "JWT",
+				scheme: "bearer",
+				type: "http",
+			},
+			"jwt",
+		)
+		.build();
 
 	const document = SwaggerModule.createDocument(app, config);
 	SwaggerModule.setup("api", app, document);

--- a/docs/guides/authentication/page.mdx
+++ b/docs/guides/authentication/page.mdx
@@ -22,7 +22,11 @@ import { UserService } from "./user.service";
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 		},
@@ -31,7 +35,11 @@ import { UserService } from "./user.service";
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 		},
@@ -40,7 +48,11 @@ import { UserService } from "./user.service";
 				authentication: {
 					type: EApiAuthenticationType.USER,
 					guard: JwtAuthGuard,
-					bearerStrategies: ["jwt"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["jwt"],
+						},
+					],
 				},
 			},
 		},
@@ -115,9 +127,9 @@ import { JwtStrategy } from "./jwt.strategy";
 export class AuthModule {}
 ```
 
-## Multiple Authentication Strategies
+## Multiple Authentication Requirements
 
-Support multiple authentication methods:
+Use `securityRequirements` to describe route-level OpenAPI security. One object is an AND group; multiple objects are OR alternatives:
 
 ```typescript
 routes: {
@@ -126,13 +138,57 @@ routes: {
       authentication: {
         type: EApiAuthenticationType.USER,
         guard: JwtAuthGuard,
-        bearerStrategies: ["jwt"],
-        securityStrategies: ["api-key"],
+        securityRequirements: [
+          {
+            bearerStrategies: ["jwt"],
+            securityStrategies: ["api-key"],
+          },
+        ],
       },
     },
   },
 }
 ```
+
+This is the only supported route-level Swagger auth shape. Older top-level `authentication.bearerStrategies` and `authentication.securityStrategies` fields are not part of the current API.
+
+For alternatives, use multiple requirement objects:
+
+```typescript
+security: {
+  authentication: {
+    type: EApiAuthenticationType.USER,
+    guard: JwtAuthGuard,
+    securityRequirements: [
+      {
+        bearerStrategies: ["jwt"],
+      },
+      {
+        securityStrategies: ["api-key"],
+      },
+    ],
+  },
+}
+```
+
+For cookie plus CSRF authentication, keep both schemes in the same requirement object:
+
+```typescript
+security: {
+  authentication: {
+    type: EApiAuthenticationType.USER,
+    guard: RefreshSessionCsrfGuard,
+    securityRequirements: [
+      {
+        cookieStrategies: ["userRefreshTokenCookie"],
+        securityStrategies: ["userSessionCsrf"],
+      },
+    ],
+  },
+}
+```
+
+The names in `securityRequirements` must match the names registered on `DocumentBuilder` with `.addBearerAuth(...)`, `.addCookieAuth(...)`, `.addApiKey(...)`, or `.addSecurity(...)`.
 
 ## API Key Authentication
 
@@ -176,7 +232,11 @@ routes: {
       authentication: {
         type: EApiAuthenticationType.USER,
         guard: ApiKeyAuthGuard,
-        securityStrategies: ["api-key"],
+        securityRequirements: [
+          {
+            securityStrategies: ["api-key"],
+          },
+        ],
       },
     },
   },
@@ -230,7 +290,11 @@ const Roles = (...roles: string[]) => SetMetadata("roles", roles);
         authentication: {
           type: EApiAuthenticationType.USER,
           guard: JwtAuthGuard,
-          bearerStrategies: ["jwt"],
+          securityRequirements: [
+            {
+              bearerStrategies: ["jwt"],
+            },
+          ],
         },
       },
       generation: {
@@ -260,7 +324,11 @@ routes: {
       authentication: {
         type: EApiAuthenticationType.USER,
         guard: JwtAuthGuard,
-        bearerStrategies: ["jwt"],
+        securityRequirements: [
+          {
+            bearerStrategies: ["jwt"],
+          },
+        ],
       },
     },
     request: {
@@ -361,22 +429,29 @@ const config = new DocumentBuilder()
 	.setVersion("1.0")
 	.addBearerAuth(
 		{
-			type: "http",
-			scheme: "bearer",
 			bearerFormat: "JWT",
-			name: "JWT",
 			description: "Enter JWT token",
-			in: "header",
+			scheme: "bearer",
+			type: "http",
 		},
-		"JWT-auth",
+		"jwt",
 	)
 	.addApiKey(
 		{
-			type: "apiKey",
-			name: "x-api-key",
 			in: "header",
+			name: "x-api-key",
+			type: "apiKey",
 		},
 		"api-key",
+	)
+	.addCookieAuth("refreshToken", undefined, "userRefreshTokenCookie")
+	.addApiKey(
+		{
+			in: "header",
+			name: "x-csrf-token",
+			type: "apiKey",
+		},
+		"userSessionCsrf",
 	)
 	.build();
 ```
@@ -394,7 +469,11 @@ routes: {
       authentication: {
         type: EApiAuthenticationType.USER,
         guard: JwtAuthGuard,
-        bearerStrategies: ["jwt"],
+        securityRequirements: [
+          {
+            bearerStrategies: ["jwt"],
+          },
+        ],
       },
     },
   },
@@ -403,7 +482,11 @@ routes: {
       authentication: {
         type: EApiAuthenticationType.USER,
         guard: JwtAuthGuard,
-        bearerStrategies: ["jwt"],
+        securityRequirements: [
+          {
+            bearerStrategies: ["jwt"],
+          },
+        ],
       },
     },
   },
@@ -412,7 +495,11 @@ routes: {
       authentication: {
         type: EApiAuthenticationType.USER,
         guard: JwtAuthGuard,
-        bearerStrategies: ["jwt"],
+        securityRequirements: [
+          {
+            bearerStrategies: ["jwt"],
+          },
+        ],
       },
     },
   },

--- a/docs/guides/transformers/page.mdx
+++ b/docs/guides/transformers/page.mdx
@@ -143,13 +143,19 @@ routes: {
 }
 ```
 
-`@ApiRouteCustom` uses the same target-first response transformer shape. Put response metadata such as `status`, `type`, `errors`, and `serialization` at the top of `response`, and put runtime response transformers under `[EApiControllerResponseTarget.RESPONSE]`:
+`@ApiRouteCustom` uses the same target-first response transformer shape. Put response metadata such as `status`, `type`, `headers`, `errors`, and `serialization` at the top of `response`, and put runtime response transformers under `[EApiControllerResponseTarget.RESPONSE]`:
 
 ```typescript
 @ApiRouteCustom<PostEntity>({
 	resource: { action: "preview", entity: PostEntity },
 	route: { method: RequestMethod.GET, path: ":id/preview" },
 	response: {
+		headers: {
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: { type: "string" },
+			},
+		},
 		status: HttpStatus.OK,
 		type: PreviewPostDTO,
 		serialization: { isEnabled: true },

--- a/src/decorator/api/method.decorator.ts
+++ b/src/decorator/api/method.decorator.ts
@@ -1,12 +1,14 @@
 import type { IApiBaseEntity } from "@interface/api-base-entity.interface";
 import type { IApiMethodProperties } from "@interface/decorator/api";
+import type { IApiRouteSecurityRequirement } from "@interface/decorator/api/route";
 import type { CanActivate, Type } from "@nestjs/common";
+import type { SecurityRequirementObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 
 import { ApiAuthorizationGuard } from "@class/api/authorization/guard.class";
 import { METHOD_API_DECORATOR_CONSTANT } from "@constant/decorator/api";
 import { EApiRouteType } from "@enum/decorator/api";
 import { applyDecorators, Delete, Get, HttpCode, HttpStatus, Patch, Post, Put, RequestMethod, SetMetadata, UseGuards } from "@nestjs/common";
-import { ApiBadRequestResponse, ApiBearerAuth, ApiConflictResponse, ApiExtraModels, ApiForbiddenResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOperation, ApiResponse, ApiSecurity, ApiTooManyRequestsResponse, ApiUnauthorizedResponse } from "@nestjs/swagger";
+import { ApiBadRequestResponse, ApiConflictResponse, ApiExtraModels, ApiForbiddenResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOperation, ApiResponse, ApiSecurity, ApiTooManyRequestsResponse, ApiUnauthorizedResponse } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import { ApiRouteBuildDiscriminatedDtoOpenApiSchema } from "@utility/api/route/discriminator";
 import { ApiRouteCollectDtoWithRegisteredChildren } from "@utility/api/route/dto";
@@ -77,6 +79,7 @@ export function ApiMethod<E extends IApiBaseEntity>(options: IApiMethodPropertie
 			ApiExtraModels(...responseDtos),
 			ApiResponse({
 				description: "Success",
+				headers: metadata.response.headers,
 				schema: ApiRouteBuildDiscriminatedDtoOpenApiSchema(
 					{
 						discriminator: metadata.response.discriminator,
@@ -93,6 +96,7 @@ export function ApiMethod<E extends IApiBaseEntity>(options: IApiMethodPropertie
 		successResponseDecorators.push(
 			ApiResponse({
 				description: "Success",
+				headers: metadata.response?.headers,
 				status: metadata.response?.status,
 				type: responseType,
 			}),
@@ -181,12 +185,10 @@ export function ApiMethod<E extends IApiBaseEntity>(options: IApiMethodPropertie
 		}
 	}
 
-	for (const strategy of metadata.security?.authentication?.bearerStrategies ?? []) {
-		decorators.push(ApiBearerAuth(strategy));
-	}
+	for (const securityRequirement of metadata.security?.authentication?.securityRequirements ?? []) {
+		const openApiSecurityRequirement: SecurityRequirementObject = buildOpenApiSecurityRequirement(securityRequirement);
 
-	for (const strategy of metadata.security?.authentication?.securityStrategies ?? []) {
-		decorators.push(ApiSecurity(strategy));
+		decorators.push(ApiSecurity(openApiSecurityRequirement));
 	}
 
 	const guards: Array<CanActivate | Type<CanActivate>> = [];
@@ -199,4 +201,19 @@ export function ApiMethod<E extends IApiBaseEntity>(options: IApiMethodPropertie
 	decorators.push(UseGuards(...guards));
 
 	return applyDecorators(...decorators);
+}
+
+/**
+ * Converts grouped route auth metadata into one OpenAPI security requirement object.
+ * @param {IApiRouteSecurityRequirement} securityRequirement - Route auth requirement group.
+ * @returns {SecurityRequirementObject} OpenAPI security requirement object.
+ */
+function buildOpenApiSecurityRequirement(securityRequirement: IApiRouteSecurityRequirement): SecurityRequirementObject {
+	const openApiSecurityRequirement: SecurityRequirementObject = {};
+
+	for (const strategy of [...(securityRequirement.bearerStrategies ?? []), ...(securityRequirement.cookieStrategies ?? []), ...(securityRequirement.securityStrategies ?? [])]) {
+		openApiSecurityRequirement[strategy] = [];
+	}
+
+	return openApiSecurityRequirement;
 }

--- a/src/decorator/api/route-custom.decorator.ts
+++ b/src/decorator/api/route-custom.decorator.ts
@@ -24,6 +24,7 @@ export function ApiRouteCustom<E extends IApiBaseEntity>(properties: IApiRouteCu
 		? {
 				discriminator: properties.response.discriminator,
 				errors: properties.response.errors,
+				headers: properties.response.headers,
 				serialization: properties.response.serialization,
 				status: properties.response.status,
 				type: properties.response.type,

--- a/src/interface/decorator/api/controller/properties/route/authentication.interface.ts
+++ b/src/interface/decorator/api/controller/properties/route/authentication.interface.ts
@@ -1,10 +1,10 @@
 import type { EApiAuthenticationType } from "@enum/decorator/api";
+import type { IApiRouteSecurityRequirement } from "@interface/decorator/api/route";
 import type { Type } from "@nestjs/common";
 import type { IAuthGuard } from "@nestjs/passport";
 
 export interface IApiControllerPropertiesRouteAuthentication {
-	bearerStrategies?: Array<string>;
 	guard: Type<IAuthGuard>;
-	securityStrategies?: Array<string>;
+	securityRequirements?: Array<IApiRouteSecurityRequirement>;
 	type: EApiAuthenticationType | string;
 }

--- a/src/interface/decorator/api/controller/properties/route/base/response/interface.ts
+++ b/src/interface/decorator/api/controller/properties/route/base/response/interface.ts
@@ -1,9 +1,11 @@
 import type { EApiControllerResponseTarget, EApiRouteType } from "@enum/decorator/api";
 import type { IApiRouteResponseSerializationProperties } from "@interface/decorator/api/route";
+import type { HeadersObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 
 import type { IApiControllerPropertiesRouteBaseResponseTarget } from "./target.interface";
 
 export interface IApiControllerPropertiesRouteBaseResponse<E, R extends EApiRouteType> {
 	[EApiControllerResponseTarget.RESPONSE]?: R extends EApiRouteType.DELETE ? never : IApiControllerPropertiesRouteBaseResponseTarget<E>;
+	headers?: HeadersObject;
 	serialization?: IApiRouteResponseSerializationProperties;
 }

--- a/src/interface/decorator/api/route/response/properties.interface.ts
+++ b/src/interface/decorator/api/route/response/properties.interface.ts
@@ -1,5 +1,6 @@
 import type { IApiResponseType } from "@interface/decorator/api/response-type.interface";
 import type { HttpStatus, Type } from "@nestjs/common";
+import type { HeadersObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 import type { TTypeDiscriminator } from "@type/decorator/api/property";
 
 import type { IApiRouteResponseSerializationProperties } from "./serialization-properties.interface";
@@ -7,6 +8,7 @@ import type { IApiRouteResponseSerializationProperties } from "./serialization-p
 export interface IApiRouteResponseProperties {
 	discriminator?: TTypeDiscriminator;
 	errors?: IApiResponseType;
+	headers?: HeadersObject;
 	serialization?: IApiRouteResponseSerializationProperties;
 	status: HttpStatus;
 	type: Array<Type<unknown>> | Type<unknown> | undefined;

--- a/src/interface/decorator/api/route/security/authentication-properties.interface.ts
+++ b/src/interface/decorator/api/route/security/authentication-properties.interface.ts
@@ -2,9 +2,10 @@ import type { EApiAuthenticationType } from "@enum/decorator/api/authentication-
 import type { Type } from "@nestjs/common";
 import type { IAuthGuard } from "@nestjs/passport";
 
+import type { IApiRouteSecurityRequirement } from "./requirement.interface";
+
 export interface IApiRouteAuthenticationProperties {
-	bearerStrategies?: Array<string>;
 	guard: Type<IAuthGuard>;
-	securityStrategies?: Array<string>;
+	securityRequirements?: Array<IApiRouteSecurityRequirement>;
 	type: EApiAuthenticationType | string;
 }

--- a/src/interface/decorator/api/route/security/index.ts
+++ b/src/interface/decorator/api/route/security/index.ts
@@ -1,3 +1,4 @@
 export { type IApiRouteAuthenticationProperties } from "./authentication-properties.interface";
 export { type IApiRouteAuthorizationProperties } from "./authorization-properties.interface";
 export { type IApiRouteSecurityProperties } from "./properties.interface";
+export { type IApiRouteSecurityRequirement } from "./requirement.interface";

--- a/src/interface/decorator/api/route/security/requirement.interface.ts
+++ b/src/interface/decorator/api/route/security/requirement.interface.ts
@@ -1,0 +1,5 @@
+export interface IApiRouteSecurityRequirement {
+	bearerStrategies?: Array<string>;
+	cookieStrategies?: Array<string>;
+	securityStrategies?: Array<string>;
+}

--- a/src/utility/api/controller/apply/decorators.utility.ts
+++ b/src/utility/api/controller/apply/decorators.utility.ts
@@ -111,6 +111,7 @@ function createRouteMetadata<E extends IApiBaseEntity>(properties: IApiControlle
 		},
 		response: {
 			errors,
+			headers: routeConfig.response?.headers,
 			serialization: routeConfig.response?.serialization ?? {
 				isEnabled: responseType !== undefined && status !== HttpStatus.NO_CONTENT,
 			},

--- a/test/e2e/swagger.e2e.test.ts
+++ b/test/e2e/swagger.e2e.test.ts
@@ -10,7 +10,7 @@ import { Test } from "@nestjs/testing";
 import { Column, Entity, PrimaryColumn } from "typeorm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { ApiAuthorizationModule, ApiController, ApiMethod, ApiPropertyDescribe, ApiPropertyObject, ApiRouteCustom, ApiServiceBase, EApiDtoType, EApiPropertyDescribeType, EApiPropertyStringType, EApiRouteType } from "../../src/index";
+import { ApiAuthorizationModule, ApiController, ApiMethod, ApiPropertyDescribe, ApiPropertyObject, ApiRouteCustom, ApiServiceBase, EApiAuthenticationType, EApiDtoType, EApiPropertyDescribeType, EApiPropertyStringType, EApiRouteType } from "../../src/index";
 
 type TSwaggerMethod = "delete" | "get" | "patch" | "post" | "put";
 type TSwaggerOperation = NonNullable<NonNullable<OpenAPIObject["paths"][string]>[TSwaggerMethod]>;
@@ -141,6 +141,8 @@ class SwaggerNestedDiscriminatorBodyDto {
 	public payload!: SwaggerNestedEmailPayloadDto | SwaggerNestedPhonePayloadDto;
 }
 
+class SwaggerAuthenticationGuard {}
+
 class SwaggerGeneratedService extends ApiServiceBase<SwaggerAutoDtoEntity> {}
 
 class SwaggerGeneratedDefaultControllerBase {
@@ -156,8 +158,31 @@ const SwaggerGeneratedDefaultController = ApiController<SwaggerAutoDtoEntity>({
 	name: "SwaggerAutoDtoResource",
 	path: "swagger-generated-default",
 	routes: {
-		[EApiRouteType.CREATE]: {},
-		[EApiRouteType.DELETE]: {},
+		[EApiRouteType.CREATE]: {
+			security: {
+				authentication: {
+					guard: SwaggerAuthenticationGuard as never,
+					securityRequirements: [
+						{
+							bearerStrategies: ["userAccessToken"],
+						},
+					],
+					type: EApiAuthenticationType.USER,
+				},
+			},
+		},
+		[EApiRouteType.DELETE]: {
+			response: {
+				headers: {
+					"Set-Cookie": {
+						description: "Clears refresh token cookie.",
+						schema: {
+							type: "string",
+						},
+					},
+				},
+			},
+		},
 		[EApiRouteType.GET]: {},
 		[EApiRouteType.GET_LIST]: {},
 		[EApiRouteType.PARTIAL_UPDATE]: {},
@@ -224,12 +249,32 @@ class SwaggerDocumentationController {
 			entity: SwaggerEntity,
 		},
 		response: {
+			headers: {
+				"X-Request-Id": {
+					description: "Request correlation id.",
+					schema: {
+						type: "string",
+					},
+				},
+			},
 			status: HttpStatus.OK,
 			type: undefined,
 		},
 		route: {
 			method: RequestMethod.POST,
 			path: "custom/:id",
+		},
+		security: {
+			authentication: {
+				guard: SwaggerAuthenticationGuard as never,
+				securityRequirements: [
+					{
+						cookieStrategies: ["userRefreshTokenCookie"],
+						securityStrategies: ["userSessionCsrf"],
+					},
+				],
+				type: EApiAuthenticationType.USER,
+			},
 		},
 	})
 	public custom(@Param() parameters: SwaggerParametersDto, @Query() query: SwaggerQueryDto, @Body() body: SwaggerRequestBodyDto): Record<string, unknown> {
@@ -311,6 +356,14 @@ class SwaggerDocumentationController {
 				propertyName: "mode",
 				shouldKeepDiscriminatorProperty: true,
 			},
+			headers: {
+				"X-Discriminated-Response": {
+					description: "Discriminated response marker.",
+					schema: {
+						type: "string",
+					},
+				},
+			},
 			status: HttpStatus.CREATED,
 			type: [SwaggerVerificationResponseDto, SwaggerSessionResponseDto],
 		},
@@ -371,7 +424,28 @@ describe("Swagger request DTO documentation (E2E)", () => {
 		app = moduleReference.createNestApplication(new FastifyAdapter());
 		await app.init();
 
-		document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+		document = SwaggerModule.createDocument(
+			app,
+			new DocumentBuilder()
+				.addBearerAuth(
+					{
+						bearerFormat: "JWT",
+						scheme: "bearer",
+						type: "http",
+					},
+					"userAccessToken",
+				)
+				.addCookieAuth("refreshToken", undefined, "userRefreshTokenCookie")
+				.addApiKey(
+					{
+						in: "header",
+						name: "x-csrf-token",
+						type: "apiKey",
+					},
+					"userSessionCsrf",
+				)
+				.build(),
+		);
 	});
 
 	afterAll(async () => {
@@ -394,6 +468,26 @@ describe("Swagger request DTO documentation (E2E)", () => {
 		const parameters = getOperation("/swagger/custom/{id}").parameters ?? [];
 
 		expect(parameters).toEqual(expect.arrayContaining([expect.objectContaining({ in: "path", name: "id" }), expect.objectContaining({ in: "query", name: "filter" })]));
+	});
+
+	it("documents custom route response headers and grouped security requirements", () => {
+		const operation = getOperation("/swagger/custom/{id}");
+		const response = operation.responses?.["200"] as { headers?: unknown } | undefined;
+
+		expect(response?.headers).toEqual({
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(operation.security).toEqual([
+			{
+				userRefreshTokenCookie: [],
+				userSessionCsrf: [],
+			},
+		]);
 	});
 
 	it("documents generated autoDto request bodies for ApiRouteCustom", () => {
@@ -434,6 +528,19 @@ describe("Swagger request DTO documentation (E2E)", () => {
 		expect(document.components?.schemas?.SwaggerSessionResponseDto).toBeDefined();
 	});
 
+	it("documents discriminated custom route response headers", () => {
+		const response = getOperation("/swagger/discriminated").responses?.["201"] as { headers?: unknown } | undefined;
+
+		expect(response?.headers).toEqual({
+			"X-Discriminated-Response": {
+				description: "Discriminated response marker.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+	});
+
 	it("registers nested ApiPropertyObject discriminator variants for custom route body DTOs", () => {
 		const operation = getOperation("/swagger/nested-discriminated");
 		const requestBody = operation.requestBody;
@@ -460,6 +567,26 @@ describe("Swagger request DTO documentation (E2E)", () => {
 		expectGeneratedDocumentation(getOperation("/swagger-generated-default", "get"), "List `SwaggerAutoDtoResources`", "Returns a paginated list of `SwaggerAutoDtoResources` resources.");
 		expectGeneratedDocumentation(getOperation("/swagger-generated-default/{id}", "patch"), "Partially update `SwaggerAutoDtoResource`", "Partially updates an existing `SwaggerAutoDtoResource` resource.");
 		expectGeneratedDocumentation(getOperation("/swagger-generated-default/{id}", "put"), "Update `SwaggerAutoDtoResource`", "Replaces an existing `SwaggerAutoDtoResource` resource.");
+	});
+
+	it("documents generated route response headers and security requirements", () => {
+		const createOperation = getOperation("/swagger-generated-default");
+		const deleteOperation = getOperation("/swagger-generated-default/{id}", "delete");
+		const deleteResponse = deleteOperation.responses?.["204"] as { headers?: unknown } | undefined;
+
+		expect(createOperation.security).toEqual([
+			{
+				userAccessToken: [],
+			},
+		]);
+		expect(deleteResponse?.headers).toEqual({
+			"Set-Cookie": {
+				description: "Clears refresh token cookie.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
 	});
 
 	it("allows generated route documentation overrides", () => {

--- a/test/unit/decorator/api/method.decorator.test.ts
+++ b/test/unit/decorator/api/method.decorator.test.ts
@@ -10,7 +10,7 @@ import { EApiAuthenticationType, EApiRouteType } from "@enum/decorator/api";
 import { GUARDS_METADATA } from "@nestjs/common/constants";
 import { HttpStatus, RequestMethod } from "@nestjs/common";
 import { DECORATORS } from "@nestjs/swagger/dist/constants";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { MethodController, MethodEmailPayloadDto, MethodEmailResponseDto, MethodEntity, MethodPhonePayloadDto, MethodPhoneResponseDto } from "./method/fixture";
 
@@ -53,7 +53,18 @@ const applyDecorator = (decorator: ReturnType<typeof ApiMethod>): void => {
 	decorator(MethodController.prototype, "handler", descriptor);
 };
 
+const readHandlerMetadata = <T>(metadataKey: string): T | undefined => (Reflect.getMetadata(metadataKey, MethodController.prototype, "handler") ?? Reflect.getMetadata(metadataKey, MethodController.prototype.handler)) as T | undefined;
+
+const readApiResponses = (): Record<string, Record<string, unknown>> => readHandlerMetadata<Record<string, Record<string, unknown>>>(DECORATORS.API_RESPONSE) ?? {};
+
 describe("ApiMethod", () => {
+	beforeEach(() => {
+		for (const metadataKey of [DECORATORS.API_EXTRA_MODELS, DECORATORS.API_RESPONSE, DECORATORS.API_SECURITY, GUARDS_METADATA, METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY]) {
+			Reflect.deleteMetadata(metadataKey, MethodController.prototype, "handler");
+			Reflect.deleteMetadata(metadataKey, MethodController.prototype.handler);
+		}
+	});
+
 	it("applies HTTP decorators for supported methods", () => {
 		for (const method of [RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.GET]) {
 			applyDecorator(ApiMethod({ metadata: createMetadata({ route: { method, path: "/secured", type: EApiRouteType.CREATE } }) }));
@@ -73,9 +84,15 @@ describe("ApiMethod", () => {
 			},
 			security: {
 				authentication: {
-					bearerStrategies: ["bearer"],
 					guard: CustomGuard as unknown as Type,
-					securityStrategies: ["apiKey"],
+					securityRequirements: [
+						{
+							bearerStrategies: ["bearer"],
+						},
+						{
+							securityStrategies: ["apiKey"],
+						},
+					],
 					type: EApiAuthenticationType.USER,
 				},
 			},
@@ -89,11 +106,189 @@ describe("ApiMethod", () => {
 
 		applyDecorator(ApiMethod({ metadata }));
 
-		const guards = (Reflect.getMetadata(GUARDS_METADATA, MethodController.prototype, "handler") as Array<unknown>) ?? (Reflect.getMetadata(GUARDS_METADATA, MethodController.prototype.handler) as Array<unknown>);
-		const securities = (Reflect.getMetadata(DECORATORS.API_SECURITY, MethodController.prototype, "handler") as Array<Record<string, Array<string>>>) ?? (Reflect.getMetadata(DECORATORS.API_SECURITY, MethodController.prototype.handler) as Array<Record<string, Array<string>>>);
+		const guards = readHandlerMetadata<Array<unknown>>(GUARDS_METADATA);
+		const securities = readHandlerMetadata<Array<Record<string, Array<string>>>>(DECORATORS.API_SECURITY);
 
 		expect(guards).toEqual(expect.arrayContaining([CustomGuard, ApiAuthorizationGuard]));
 		expect(securities).toEqual(expect.arrayContaining([{ bearer: [] }, { apiKey: [] }]));
+	});
+
+	it("writes normal success response headers into swagger metadata", () => {
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					response: {
+						headers: {
+							"X-Request-Id": {
+								description: "Request correlation id.",
+								schema: {
+									type: "string",
+								},
+							},
+						},
+						status: HttpStatus.OK,
+						type: MethodEmailResponseDto,
+					},
+				}),
+			}),
+		);
+
+		expect(readApiResponses()[HttpStatus.OK]?.headers).toEqual({
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(readApiResponses()[HttpStatus.OK]?.type).toBe(MethodEmailResponseDto);
+	});
+
+	it("writes no-content success response headers into swagger metadata", () => {
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					response: {
+						headers: {
+							"Set-Cookie": {
+								description: "Clears refresh token cookie.",
+								schema: {
+									type: "string",
+								},
+							},
+						},
+						status: HttpStatus.NO_CONTENT,
+						type: undefined,
+					},
+				}),
+			}),
+		);
+
+		expect(readApiResponses()[HttpStatus.NO_CONTENT]?.headers).toEqual({
+			"Set-Cookie": {
+				description: "Clears refresh token cookie.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(readApiResponses()[HttpStatus.NO_CONTENT]?.type).toBeUndefined();
+	});
+
+	it("writes one grouped security requirement object for combined cookie and csrf schemes", () => {
+		class CustomGuard {}
+
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					security: {
+						authentication: {
+							guard: CustomGuard as unknown as Type,
+							securityRequirements: [
+								{
+									cookieStrategies: ["userRefreshTokenCookie"],
+									securityStrategies: ["userSessionCsrf"],
+								},
+							],
+							type: EApiAuthenticationType.USER,
+						},
+					},
+				}),
+			}),
+		);
+
+		expect(readHandlerMetadata<Array<Record<string, Array<string>>>>(DECORATORS.API_SECURITY)).toEqual([
+			{
+				userRefreshTokenCookie: [],
+				userSessionCsrf: [],
+			},
+		]);
+	});
+
+	it("writes one grouped security requirement object for bearer, cookie, and generic schemes", () => {
+		class CustomGuard {}
+
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					security: {
+						authentication: {
+							guard: CustomGuard as unknown as Type,
+							securityRequirements: [
+								{
+									bearerStrategies: ["userAccessToken"],
+									cookieStrategies: ["userRefreshTokenCookie"],
+									securityStrategies: ["userSessionCsrf"],
+								},
+							],
+							type: EApiAuthenticationType.USER,
+						},
+					},
+				}),
+			}),
+		);
+
+		expect(readHandlerMetadata<Array<Record<string, Array<string>>>>(DECORATORS.API_SECURITY)).toEqual([
+			{
+				userAccessToken: [],
+				userRefreshTokenCookie: [],
+				userSessionCsrf: [],
+			},
+		]);
+	});
+
+	it("preserves empty security requirement objects in swagger metadata", () => {
+		class CustomGuard {}
+
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					security: {
+						authentication: {
+							guard: CustomGuard as unknown as Type,
+							securityRequirements: [{}],
+							type: EApiAuthenticationType.USER,
+						},
+					},
+				}),
+			}),
+		);
+
+		expect(readHandlerMetadata<Array<Record<string, Array<string>>>>(DECORATORS.API_SECURITY)).toEqual([{}]);
+	});
+
+	it("writes multiple security requirement objects for alternative schemes", () => {
+		class CustomGuard {}
+
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					security: {
+						authentication: {
+							guard: CustomGuard as unknown as Type,
+							securityRequirements: [
+								{
+									bearerStrategies: ["userAccessToken"],
+								},
+								{
+									securityStrategies: ["serviceAccountSignedRequest"],
+								},
+							],
+							type: EApiAuthenticationType.USER,
+						},
+					},
+				}),
+			}),
+		);
+
+		expect(readHandlerMetadata<Array<Record<string, Array<string>>>>(DECORATORS.API_SECURITY)).toEqual([
+			{
+				userAccessToken: [],
+			},
+			{
+				serviceAccountSignedRequest: [],
+			},
+		]);
 	});
 
 	it("stores unified route metadata on the handler", () => {
@@ -128,13 +323,51 @@ describe("ApiMethod", () => {
 			}),
 		);
 
-		const responses = (Reflect.getMetadata(DECORATORS.API_RESPONSE, MethodController.prototype, "handler") ?? Reflect.getMetadata(DECORATORS.API_RESPONSE, MethodController.prototype.handler)) as unknown;
-		const extraModels = (Reflect.getMetadata(DECORATORS.API_EXTRA_MODELS, MethodController.prototype, "handler") ?? Reflect.getMetadata(DECORATORS.API_EXTRA_MODELS, MethodController.prototype.handler)) as Array<unknown>;
+		const responses = readHandlerMetadata<unknown>(DECORATORS.API_RESPONSE);
+		const extraModels = readHandlerMetadata<Array<unknown>>(DECORATORS.API_EXTRA_MODELS);
 
 		expect(JSON.stringify(responses)).toContain("oneOf");
 		expect(JSON.stringify(responses)).toContain("channel");
 		expect(extraModels).toEqual(expect.arrayContaining([MethodEmailResponseDto, MethodPhoneResponseDto]));
 		expect(extraModels).toEqual(expect.arrayContaining([MethodEmailPayloadDto, MethodPhonePayloadDto]));
+	});
+
+	it("writes discriminated success response headers into swagger metadata", () => {
+		applyDecorator(
+			ApiMethod({
+				metadata: createMetadata({
+					response: {
+						discriminator: {
+							mapping: {
+								email: MethodEmailResponseDto,
+								phone: MethodPhoneResponseDto,
+							},
+							propertyName: "channel",
+						},
+						headers: {
+							"X-Request-Id": {
+								description: "Request correlation id.",
+								schema: {
+									type: "string",
+								},
+							},
+						},
+						status: HttpStatus.OK,
+						type: [MethodEmailResponseDto, MethodPhoneResponseDto],
+					},
+				}),
+			}),
+		);
+
+		expect(readApiResponses()[HttpStatus.OK]?.headers).toEqual({
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(JSON.stringify(readApiResponses()[HttpStatus.OK]?.schema)).toContain("oneOf");
 	});
 
 	it("throws when discriminated success response is missing discriminator metadata", () => {

--- a/test/unit/decorator/api/route-custom.decorator.test.ts
+++ b/test/unit/decorator/api/route-custom.decorator.test.ts
@@ -4,6 +4,7 @@ import { METHOD_API_DECORATOR_CONSTANT } from "@constant/decorator/api";
 import { ApiRouteCustom } from "@decorator/api";
 import { EApiControllerRequestTransformerType, EApiControllerResponseTarget } from "@enum/decorator/api";
 import { HttpStatus, RequestMethod } from "@nestjs/common";
+import { DECORATORS } from "@nestjs/swagger/dist/constants";
 import { describe, expect, it } from "vitest";
 
 import { RouteCustomController, RouteCustomEmailResponseDto, RouteCustomEntity, RouteCustomPhoneResponseDto } from "./route-custom/fixture";
@@ -29,6 +30,14 @@ describe("ApiRouteCustom", () => {
 						},
 					],
 				},
+				headers: {
+					"Set-Cookie": {
+						description: "Sets refresh token cookie.",
+						schema: {
+							type: "string",
+						},
+					},
+				},
 				serialization: {
 					isEnabled: true,
 				},
@@ -43,9 +52,18 @@ describe("ApiRouteCustom", () => {
 
 		const metadata = (Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY, descriptor.value) ?? Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY, RouteCustomController.prototype.handler) ?? Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY, RouteCustomController.prototype, "handler")) as Record<string, unknown>;
 		const runtimeProperties = (Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_RUNTIME_PROPERTIES_METADATA_KEY, descriptor.value) ?? Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_RUNTIME_PROPERTIES_METADATA_KEY, RouteCustomController.prototype.handler) ?? Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_RUNTIME_PROPERTIES_METADATA_KEY, RouteCustomController.prototype, "handler")) as Record<string, unknown>;
+		const responses = (Reflect.getMetadata(DECORATORS.API_RESPONSE, descriptor.value) ?? Reflect.getMetadata(DECORATORS.API_RESPONSE, RouteCustomController.prototype.handler) ?? Reflect.getMetadata(DECORATORS.API_RESPONSE, RouteCustomController.prototype, "handler")) as Record<number, Record<string, unknown>>;
 
 		expect(metadata.response).toEqual({
 			errors: undefined,
+			headers: {
+				"Set-Cookie": {
+					description: "Sets refresh token cookie.",
+					schema: {
+						type: "string",
+					},
+				},
+			},
 			serialization: {
 				isEnabled: true,
 			},
@@ -53,6 +71,14 @@ describe("ApiRouteCustom", () => {
 			type: undefined,
 		});
 		expect(metadata.response).not.toHaveProperty(EApiControllerResponseTarget.RESPONSE);
+		expect(responses[HttpStatus.OK]?.headers).toEqual({
+			"Set-Cookie": {
+				description: "Sets refresh token cookie.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
 		expect(runtimeProperties.response).toEqual({
 			[EApiControllerResponseTarget.RESPONSE]: {
 				transformers: [

--- a/test/unit/utility/api/controller/apply/decorators.utility.test.ts
+++ b/test/unit/utility/api/controller/apply/decorators.utility.test.ts
@@ -1,9 +1,12 @@
 import type { IApiControllerProperties } from "@interface/decorator/api";
 import type { IApiEntity } from "@interface/entity";
+import type { TApiControllerPropertiesRoute } from "@type/decorator/api/controller";
 
-import { EApiRouteType } from "@enum/decorator/api";
+import { METHOD_API_DECORATOR_CONSTANT } from "@constant/decorator/api";
+import { EApiAuthenticationType, EApiDtoType, EApiRouteType } from "@enum/decorator/api";
 import { METHOD_METADATA, PATH_METADATA } from "@nestjs/common/constants";
-import { RequestMethod } from "@nestjs/common";
+import { HttpStatus, RequestMethod } from "@nestjs/common";
+import { DECORATORS } from "@nestjs/swagger/dist/constants";
 import { ApiControllerApplyDecorators } from "@utility/api/controller/apply/decorators.utility";
 import { describe, expect, it } from "vitest";
 
@@ -11,28 +14,113 @@ class DecoratorEntity {
 	public id?: string;
 }
 
+class DecoratorGuard {}
+
+const entityMetadata: IApiEntity<DecoratorEntity> = {
+	columns: [],
+	name: "DecoratorEntity",
+	primaryKey: { name: "id" } as never,
+	tableName: "decorator_entities",
+};
+
+const properties: IApiControllerProperties<DecoratorEntity> = {
+	entity: DecoratorEntity,
+	routes: {},
+};
+
 describe("ApiControllerApplyDecorators", () => {
 	it("applies route metadata for GET handlers", () => {
-		const entityMetadata: IApiEntity<DecoratorEntity> = {
-			columns: [],
-			name: "DecoratorEntity",
-			primaryKey: { name: "id" } as never,
-			tableName: "decorator_entities",
-		};
-		const properties: IApiControllerProperties<DecoratorEntity> = {
-			entity: DecoratorEntity,
-			routes: {},
-		};
-		const routeConfig = {
+		const routeConfig: TApiControllerPropertiesRoute<DecoratorEntity, EApiRouteType.GET> = {
 			dto: {
-				response: DecoratorEntity,
+				[EApiDtoType.RESPONSE]: DecoratorEntity,
+			},
+			response: {
+				headers: {
+					"X-Request-Id": {
+						description: "Request correlation id.",
+						schema: {
+							type: "string",
+						},
+					},
+				},
+			},
+			security: {
+				authentication: {
+					guard: DecoratorGuard as never,
+					securityRequirements: [
+						{
+							cookieStrategies: ["userRefreshTokenCookie"],
+							securityStrategies: ["userSessionCsrf"],
+						},
+					],
+					type: EApiAuthenticationType.USER,
+				},
 			},
 		};
 		const targetMethod = () => undefined;
 
-		ApiControllerApplyDecorators(targetMethod as never, entityMetadata, properties, EApiRouteType.GET, "get", routeConfig as never, []);
+		ApiControllerApplyDecorators(targetMethod as never, entityMetadata, properties, EApiRouteType.GET, "get", routeConfig, []);
 
 		expect(Reflect.getMetadata(PATH_METADATA, targetMethod)).toBe(":id");
 		expect(Reflect.getMetadata(METHOD_METADATA, targetMethod)).toBe(RequestMethod.GET);
+		expect(Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY, targetMethod)?.response?.headers).toEqual({
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(Reflect.getMetadata(DECORATORS.API_RESPONSE, targetMethod)?.[HttpStatus.OK]?.headers).toEqual({
+			"X-Request-Id": {
+				description: "Request correlation id.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(Reflect.getMetadata(DECORATORS.API_SECURITY, targetMethod)).toEqual([
+			{
+				userRefreshTokenCookie: [],
+				userSessionCsrf: [],
+			},
+		]);
+	});
+
+	it("applies generated DELETE no-content response headers", () => {
+		const routeConfig: TApiControllerPropertiesRoute<DecoratorEntity, EApiRouteType.DELETE> = {
+			response: {
+				headers: {
+					"Set-Cookie": {
+						description: "Clears refresh token cookie.",
+						schema: {
+							type: "string",
+						},
+					},
+				},
+			},
+		};
+		const targetMethod = () => undefined;
+
+		ApiControllerApplyDecorators(targetMethod as never, entityMetadata, properties, EApiRouteType.DELETE, "delete", routeConfig, []);
+
+		expect(Reflect.getMetadata(PATH_METADATA, targetMethod)).toBe(":id");
+		expect(Reflect.getMetadata(METHOD_METADATA, targetMethod)).toBe(RequestMethod.DELETE);
+		expect(Reflect.getMetadata(METHOD_API_DECORATOR_CONSTANT.ROUTE_METADATA_KEY, targetMethod)?.response?.headers).toEqual({
+			"Set-Cookie": {
+				description: "Clears refresh token cookie.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
+		expect(Reflect.getMetadata(DECORATORS.API_RESPONSE, targetMethod)?.[HttpStatus.NO_CONTENT]?.headers).toEqual({
+			"Set-Cookie": {
+				description: "Clears refresh token cookie.",
+				schema: {
+					type: "string",
+				},
+			},
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Add Swagger/OpenAPI response header metadata for custom and generated routes.
- Replace flat auth strategy fields with grouped `securityRequirements` for correct AND/OR OpenAPI semantics.
- Expand unit and e2e coverage for headers, grouped security, generated routes, custom routes, and migration docs.

## Test plan
- `npm run lint:all`
- `npm run test:unit`
- `npm run build`
- `npm run test:e2e`
- Focused Swagger unit and e2e tests
- Stale auth/docs searches