### PR TITLE
Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"branch": "npx @elsikora/git-branch-lint -b",
 		"prebuild": "rimraf dist",
 		"build": "npm run prebuild && rollup -c",
+		"postbuild": "node scripts/check-declaration-imports.cjs",
 		"commit": "cz",
 		"format": "prettier --check .",
 		"format:fix": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elsikora/nestjs-crud-automator",
-	"version": "3.0.0",
+	"version": "3.0.1-dev.1",
 	"description": "A library for automating the creation of CRUD operations in NestJS.",
 	"keywords": [
 		"NestJS",

--- a/scripts/check-declaration-imports.cjs
+++ b/scripts/check-declaration-imports.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const declarationRoots = ["dist/esm", "dist/cjs"].map((directoryPath) => path.resolve(directoryPath));
+const invalidDeclarationPaths = [];
+
+function scanDirectory(directoryPath) {
+	for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+		const entryPath = path.join(directoryPath, entry.name);
+
+		if (entry.isDirectory()) {
+			scanDirectory(entryPath);
+			continue;
+		}
+
+		if (!entry.name.endsWith(".d.ts")) {
+			continue;
+		}
+
+		if (fs.readFileSync(entryPath, "utf8").includes("node_modules/")) {
+			invalidDeclarationPaths.push(path.relative(process.cwd(), entryPath));
+		}
+	}
+}
+
+for (const declarationRoot of declarationRoots) {
+	if (!fs.existsSync(declarationRoot)) {
+		process.stderr.write(`Declaration output does not exist: ${declarationRoot}\n`);
+		process.exit(1);
+	}
+
+	scanDirectory(declarationRoot);
+}
+
+if (invalidDeclarationPaths.length > 0) {
+	process.stderr.write(`Generated declarations contain local node_modules paths:\n${invalidDeclarationPaths.map((filePath) => `- ${filePath}`).join("\n")}\n`);
+	process.exit(1);
+}
+
+process.stdout.write("Generated declaration imports are package-relative.\n");

--- a/src/decorator/api/function/get/list.decorator.ts
+++ b/src/decorator/api/function/get/list.decorator.ts
@@ -5,7 +5,7 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiFunctionGetListExecutorProperties, IApiFunctionProperties, IApiGetListResponseResult } from "@interface/decorator/api";
 import type { TApiFunctionGetListProperties } from "@type/decorator/api/function";
 import type { EntityManager, Repository } from "typeorm";
-import type { FindManyOptions } from "typeorm/index";
+import type { FindManyOptions } from "typeorm";
 
 import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
 import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";

--- a/src/decorator/api/function/get/many.decorator.ts
+++ b/src/decorator/api/function/get/many.decorator.ts
@@ -5,7 +5,7 @@ import type { IApiSubscriberFunctionExecutionContextData } from "@interface/clas
 import type { IApiFunctionGetManyExecutorProperties, IApiFunctionProperties } from "@interface/decorator/api";
 import type { TApiFunctionGetManyProperties } from "@type/decorator/api/function";
 import type { EntityManager, Repository } from "typeorm";
-import type { FindManyOptions } from "typeorm/index";
+import type { FindManyOptions } from "typeorm";
 
 import { ApiFunctionContextStorage } from "@class/api/function/context-storage.class";
 import { ApiSubscriberExecutor } from "@class/api/subscriber/executor.class";

--- a/src/type/decorator/api/function/get/list/properties/type.ts
+++ b/src/type/decorator/api/function/get/list/properties/type.ts
@@ -1,3 +1,3 @@
-import type { FindManyOptions } from "typeorm/index";
+import type { FindManyOptions } from "typeorm";
 
 export type TApiFunctionGetListProperties<E> = FindManyOptions<E>;

--- a/src/type/decorator/api/function/get/list/properties/where.type.ts
+++ b/src/type/decorator/api/function/get/list/properties/where.type.ts
@@ -1,5 +1,4 @@
-import type { FindOperator } from "typeorm/find-options/FindOperator";
-import type { FindOptionsWhere } from "typeorm/index";
+import type { FindOperator, FindOptionsWhere } from "typeorm";
 
 export type TApiFunctionGetListPropertiesWhere<E> = {
 	createdAt?: FindOperator<Date>;

--- a/src/type/utility/api/controller/transform-data/object-to-transform.type.ts
+++ b/src/type/utility/api/controller/transform-data/object-to-transform.type.ts
@@ -1,6 +1,6 @@
 import type { IApiGetListResponseResult } from "@interface/decorator/api";
 import type { TApiControllerGetListQuery } from "@type/decorator/api/controller";
-import type { DeepPartial } from "typeorm/index";
+import type { DeepPartial } from "typeorm";
 
 export type TApiControllerTransformDataObjectToTransform<E> = {
 	body?: DeepPartial<E>;

--- a/src/type/utility/date/keys.type.ts
+++ b/src/type/utility/date/keys.type.ts
@@ -1,3 +1,4 @@
-import type { PickKeysByType } from "typeorm/common/PickKeysByType";
-
-export type TDateKeys<E> = PickKeysByType<E, Date>;
+export type TDateKeys<E> = keyof {
+	[P in keyof E as E[P] extends Date ? P : never]: E[P];
+} &
+	string;

--- a/src/type/utility/non-date-keys.type.ts
+++ b/src/type/utility/non-date-keys.type.ts
@@ -1,3 +1,3 @@
-import type { PickKeysByType } from "typeorm/common/PickKeysByType";
+import type { TDateKeys } from "@type/utility/date";
 
-export type TNonDateKeys<E> = Omit<E, keyof PickKeysByType<E, Date>>;
+export type TNonDateKeys<E> = Omit<E, keyof TDateKeys<E>>;

--- a/src/utility/api/controller/get-list/transform/filter.utility.ts
+++ b/src/utility/api/controller/get-list/transform/filter.utility.ts
@@ -3,7 +3,7 @@ import type { IApiEntity, IApiEntityColumn } from "@interface/entity";
 import type { Type } from "@nestjs/common";
 import type { IAuthGuard } from "@nestjs/passport";
 import type { TApiPropertyDescribeProperties } from "@type/decorator/api/property";
-import type { FindOptionsWhere } from "typeorm/index";
+import type { FindOptionsWhere } from "typeorm";
 
 import { PROPERTY_DESCRIBE_DECORATOR_API_CONSTANT } from "@constant/decorator/api";
 import { EApiDtoType, EApiPropertyDescribeType, EApiRouteType } from "@enum/decorator/api";

--- a/src/utility/api/controller/get-list/transform/operation.utility.ts
+++ b/src/utility/api/controller/get-list/transform/operation.utility.ts
@@ -1,4 +1,4 @@
-import type { FindOperator } from "typeorm/find-options/FindOperator";
+import type { FindOperator } from "typeorm";
 
 import { EFilterOperation } from "@enum/filter";
 import { Between, Equal, ILike, In, IsNull, LessThan, LessThanOrEqual, Like, MoreThan, MoreThanOrEqual, Not } from "typeorm";

--- a/src/utility/dto/get/get-list-query-base-class.utility.ts
+++ b/src/utility/dto/get/get-list-query-base-class.utility.ts
@@ -1,6 +1,6 @@
 import type { IApiControllerGetListQueryPlan, IApiControllerGetListQueryPlanOrderField } from "@interface/class/api/controller/get-list/query";
 import type { Type } from "@nestjs/common";
-import type { ObjectLiteral } from "typeorm/index";
+import type { ObjectLiteral } from "typeorm";
 
 import { GET_LIST_QUERY_DTO_FACTORY_CONSTANT } from "@constant/factory-dto-get-list-query.constant";
 import { ApiPropertyEnum } from "@decorator/api/property/enum.decorator";


### PR DESCRIPTION
## Summary
- promote the beta-verified TypeORM declaration portability fix from `dev` to `main`
- keep `@nestjs/swagger` pinned at `11.4.2`; this promotion contains no Swagger dependency or compatibility changes
- enforce a postbuild guard against local `node_modules` paths in generated ESM and CJS declarations

## Test plan
- [x] hotfix PR #150: Test, Qodana, Snyk, and mirror checks passed
- [x] post-merge `dev`: Test, Qodana, Snyk, both mirror workflows, and release workflow passed
- [x] semantic-release published `3.0.1-dev.1` on the beta channel
- [x] clean-installed published `3.0.1-dev.1` with `@nestjs/swagger@11.4.2`
- [x] verified published ESM and CJS root imports
- [x] strict consumer `tsc` passed with `skipLibCheck: false`